### PR TITLE
Bugfix: Introduce own exception for merge conflicts

### DIFF
--- a/src/main/java/com/cloudogu/scm/review/pullrequest/api/MergeConflictException.java
+++ b/src/main/java/com/cloudogu/scm/review/pullrequest/api/MergeConflictException.java
@@ -1,0 +1,32 @@
+package com.cloudogu.scm.review.pullrequest.api;
+
+import sonia.scm.ContextEntry;
+import sonia.scm.ExceptionWithContext;
+import sonia.scm.repository.NamespaceAndName;
+import sonia.scm.repository.api.MergeCommandResult;
+
+import java.util.List;
+
+import static sonia.scm.ContextEntry.ContextBuilder.entity;
+
+class MergeConflictException extends ExceptionWithContext {
+  private static final String CODE = "DTRhFJFgU1";
+
+  MergeConflictException(NamespaceAndName namespaceAndName, String source, String target, MergeCommandResult mergeResult) {
+    super(
+      createContext(namespaceAndName, source, target, mergeResult),
+      String.format("conflict in merge between %s and %s", source, target));
+  }
+
+  private static List<ContextEntry> createContext(NamespaceAndName namespaceAndName, String source, String target, MergeCommandResult mergeResult) {
+    return entity("files", String.join(", ", mergeResult.getFilesWithConflict()))
+      .in("branches", String.format("%s -> %s", source, target))
+      .in(namespaceAndName)
+      .build();
+  }
+
+  @Override
+  public String getCode() {
+    return CODE;
+  }
+}

--- a/src/main/resources/locales/de/plugins.json
+++ b/src/main/resources/locales/de/plugins.json
@@ -194,5 +194,11 @@
         "description": "Darf Pull-Requests akzeptieren (mergen) oder ablehnen (für den Merge wird zusätzlich die Push-Berechtigung benötigt)"
       }
     }
+  },
+  "errors": {
+    "DTRhFJFgU1": {
+      "displayName": "Merge Konflikte",
+      "description": "Die Branches konnten nicht gemerged werden, da Konflikte existieren."
+    }
   }
 }

--- a/src/main/resources/locales/en/plugins.json
+++ b/src/main/resources/locales/en/plugins.json
@@ -194,5 +194,11 @@
         "description": "May merge or reject pull requests (merge needs additional permission to push the repository)"
       }
     }
+  },
+  "errors": {
+    "DTRhFJFgU1": {
+      "displayName": "Merge conflict",
+      "description": "The branches could not be merged because there were merge conflicts."
+    }
   }
 }

--- a/src/test/java/com/cloudogu/scm/review/pullrequest/api/MergeResourceTest.java
+++ b/src/test/java/com/cloudogu/scm/review/pullrequest/api/MergeResourceTest.java
@@ -67,7 +67,7 @@ class MergeResourceTest {
   }
 
   @Test
-  void shouldReturnConflictsIfMergeNotSuccessful() throws URISyntaxException, IOException {
+  void shouldThrowExceptionIfMergeNotSuccessful() throws URISyntaxException, IOException {
     ImmutableList<String> conflicts = ImmutableList.of("a", "b");
     when(mergeService.merge(any(), any(), any())).thenReturn(MergeCommandResult.failure(conflicts));
     byte[] mergeCommitJson = loadJson("com/cloudogu/scm/review/mergeCommit.json");
@@ -75,7 +75,8 @@ class MergeResourceTest {
     MockHttpRequest request = createHttpRequest(MERGE_URL, mergeCommitJson);
 
     dispatcher.invoke(request, response);
-    assertThat(response.getStatus()).isEqualTo(409);
+    assertThat(response.getStatus()).isEqualTo(400);
+    assertThat(response.getContentAsString()).contains("MergeConflictException", "conflict in merge between squash and master");
   }
 
   @Test


### PR DESCRIPTION
Doing so, we do not have to implement an explicit handling of merge
conflicts in the frontend.