### PR TITLE
Do not remove line in update step

### DIFF
--- a/src/main/java/com/cloudogu/scm/review/update/AddTypeToCommentUpdateStep.java
+++ b/src/main/java/com/cloudogu/scm/review/update/AddTypeToCommentUpdateStep.java
@@ -1,46 +1,126 @@
 package com.cloudogu.scm.review.update;
 
-import com.cloudogu.scm.review.comment.service.CommentType;
-import com.cloudogu.scm.review.comment.service.PullRequestComments;
 import com.google.inject.Inject;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+import sonia.scm.migration.UpdateException;
 import sonia.scm.migration.UpdateStep;
 import sonia.scm.plugin.Extension;
-import sonia.scm.repository.Repository;
-import sonia.scm.repository.RepositoryDAO;
-import sonia.scm.repository.xml.XmlRepositoryDAO;
-import sonia.scm.store.DataStore;
-import sonia.scm.store.DataStoreFactory;
+import sonia.scm.repository.RepositoryLocationResolver;
 import sonia.scm.version.Version;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerConfigurationException;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
 
 @Extension
 public class AddTypeToCommentUpdateStep implements UpdateStep {
 
-  private static final Logger LOG = LoggerFactory.getLogger(AddTypeToCommentUpdateStep.class);
-  private static final String STORE_NAME = "pullRequestComment";
-  private final RepositoryDAO repositoryDAO;
-  private final DataStoreFactory dataStoreFactory;
+  private RepositoryLocationResolver.RepositoryLocationResolverInstance<Path> locationResolver;
 
   @Inject
-  public AddTypeToCommentUpdateStep(XmlRepositoryDAO repositoryDAO, DataStoreFactory dataStoreFactory) {
-    this.repositoryDAO = repositoryDAO;
-    this.dataStoreFactory = dataStoreFactory;
+  public AddTypeToCommentUpdateStep(RepositoryLocationResolver locationResolver) {
+    this.locationResolver = locationResolver.forClass(Path.class);
   }
 
   @Override
   public void doUpdate() {
-    for (Repository repository : repositoryDAO.getAll()) {
-      DataStore<PullRequestComments> dataStore = dataStoreFactory.withType(PullRequestComments.class).withName(STORE_NAME).forRepository(repository).build();
-      LOG.debug("update pullrequest comments for repository with id {}", repository.getId());
-      dataStore.getAll().forEach((key, properties) -> properties.getComments().forEach(comment -> {
-          if (comment.getType() == null) {
-            comment.setType(CommentType.COMMENT);
-          }
-          dataStore.put(key, properties);
-        })
-      );
+    locationResolver.forAllLocations((repositoryId, path) -> {
+      Path storePath = path.resolve("store").resolve("data").resolve("pullRequestComment");
+      if (Files.isDirectory(storePath)) {
+        try {
+          updateStorePath(storePath);
+        } catch (IOException e) {
+          throw new UpdateException("could not update path " + storePath, e);
+        }
+      }
+    });
+  }
+
+  private void updateStorePath(Path storePath) throws IOException {
+    try (Stream<Path> files = Files.list(storePath)) {
+      files.forEach(storeFile -> {
+        try {
+          updateStoreFile(storeFile);
+        } catch (ParserConfigurationException | IOException | SAXException | TransformerException e) {
+          throw new UpdateException("could not parse comment file " + storeFile + " in path " + storePath, e);
+        }
+      });
     }
+  }
+
+  private void updateStoreFile(Path storeFile) throws ParserConfigurationException, IOException, SAXException, TransformerException {
+    Document document = createDocumentBuilder().parse(storeFile.toFile());
+
+    List<Node> nodes = extractCommentNodes(document);
+    nodes.stream()
+      .filter(this::hasNoType)
+      .forEach(node -> addCommentType(document, node));
+    writeChangedNodes(storeFile, document, nodes);
+  }
+
+  private boolean hasNoType(Node commentNode) {
+    NodeList childNodes = commentNode.getChildNodes();
+    for (int i = 0; i < childNodes.getLength(); ++i) {
+      if (childNodes.item(i).getNodeName().equals("type")) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private void writeChangedNodes(Path storeFile, Document document, List<Node> nodes) throws TransformerException {
+    if (!nodes.isEmpty()) {
+      Transformer transformer = createTransformer();
+      transformer.transform(new DOMSource(document), new StreamResult(storeFile.toFile()));
+    }
+  }
+
+  private Transformer createTransformer() throws TransformerConfigurationException {
+    TransformerFactory factory = TransformerFactory.newInstance();
+    factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+    Transformer transformer = factory.newTransformer();
+    transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+    return factory.newTransformer();
+  }
+
+  private List<Node> extractCommentNodes(Document document) {
+    NodeList commentNodeList = document.getDocumentElement().getElementsByTagName("comment");
+
+    List<Node> commentNodes = new ArrayList<>();
+    for (int i = 0; i < commentNodeList.getLength(); ++i) {
+      commentNodes.add(commentNodeList.item(i));
+    }
+    return commentNodes;
+  }
+
+  private void addCommentType(Document document, Node commentNode) {
+    Element newtypeNode = document.createElement("type");
+    newtypeNode.setTextContent("COMMENT");
+    commentNode.appendChild(newtypeNode);
+  }
+
+  private DocumentBuilder createDocumentBuilder() throws ParserConfigurationException {
+    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+    factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+    return factory.newDocumentBuilder();
   }
 
   @Override

--- a/src/main/java/com/cloudogu/scm/review/update/AddTypeToCommentUpdateStep.java
+++ b/src/main/java/com/cloudogu/scm/review/update/AddTypeToCommentUpdateStep.java
@@ -71,15 +71,20 @@ public class AddTypeToCommentUpdateStep implements UpdateStep {
 
     List<Node> nodes = extractCommentNodes(document);
     nodes.stream()
+      .filter(this::isNotTextOnlyNode)
       .filter(this::hasNoType)
       .forEach(node -> addCommentType(document, node));
     writeChangedNodes(storeFile, document, nodes);
   }
 
+  private boolean isNotTextOnlyNode(Node commentNode) {
+    return "pull-request-comments".equals(commentNode.getParentNode().getNodeName());
+  }
+
   private boolean hasNoType(Node commentNode) {
     NodeList childNodes = commentNode.getChildNodes();
     for (int i = 0; i < childNodes.getLength(); ++i) {
-      if (childNodes.item(i).getNodeName().equals("type")) {
+      if ("type".equals(childNodes.item(i).getNodeName())) {
         return false;
       }
     }

--- a/src/test/java/com/cloudogu/scm/review/update/AddTypeToCommentUpdateStepTest.java
+++ b/src/test/java/com/cloudogu/scm/review/update/AddTypeToCommentUpdateStepTest.java
@@ -3,82 +3,94 @@ package com.cloudogu.scm.review.update;
 import com.cloudogu.scm.review.comment.service.Comment;
 import com.cloudogu.scm.review.comment.service.CommentType;
 import com.cloudogu.scm.review.comment.service.PullRequestComments;
+import com.google.common.io.Resources;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junitpioneer.jupiter.TempDirectory;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import sonia.scm.repository.Repository;
-import sonia.scm.repository.xml.XmlRepositoryDAO;
-import sonia.scm.store.DataStore;
-import sonia.scm.store.DataStoreFactory;
-import sonia.scm.store.InMemoryDataStore;
-import sonia.scm.store.InMemoryDataStoreFactory;
+import sonia.scm.repository.RepositoryLocationResolver;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
+import javax.xml.bind.JAXB;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.function.BiConsumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
-import static sonia.scm.repository.RepositoryTestData.createHeartOfGold;
 
-@ExtendWith(MockitoExtension.class)
+@ExtendWith({MockitoExtension.class, TempDirectory.class})
 class AddTypeToCommentUpdateStepTest {
 
   @Mock
-  XmlRepositoryDAO repositoryDAO;
+  private RepositoryLocationResolver.RepositoryLocationResolverInstance<Path> resolverInstance;
 
   private AddTypeToCommentUpdateStep updateStep;
-  private DataStoreFactory dataStoreFactory = new InMemoryDataStoreFactory(new InMemoryDataStore());
-  private DataStore<PullRequestComments> dataStore;
-  private Repository repository = createHeartOfGold();
 
-  private final static String STORE_NAME = "pullRequestComment";
-
-  @BeforeEach
-  void init() {
-    dataStore = dataStoreFactory.withType(PullRequestComments.class).withName(STORE_NAME).forRepository(repository).build();
-    updateStep = new AddTypeToCommentUpdateStep(repositoryDAO, dataStoreFactory);
-  }
+  @Mock
+  private RepositoryLocationResolver resolver;
+  private Path store;
 
   @BeforeEach
-  void mockRepositories() {
-    when(repositoryDAO.getAll()).thenReturn(Collections.singletonList(repository));
+  void init(@TempDirectory.TempDir Path temp) throws IOException {
+    when(resolver.forClass(Path.class)).thenReturn(resolverInstance);
+    updateStep = new AddTypeToCommentUpdateStep(resolver);
+
+    store = createStore(temp);
+
+    doAnswer(ic -> {
+      BiConsumer<String, Path> consumer = ic.getArgument(0);
+      consumer.accept("repo", temp);
+      return null;
+    }).when(resolverInstance).forAllLocations(any());
   }
 
   @Test
-  void shouldUpdatePullRequestCommentData() {
-    Comment comment1 = new Comment();
-    comment1.setComment("comment1");
-    comment1.setAuthor("trillian");
-    comment1.setType(CommentType.COMMENT);
-    Comment comment2 = new Comment();
-    comment2.setAuthor("edi");
-    comment2.setComment("comment2");
-    comment2.setType(null);
-    PullRequestComments comments = new PullRequestComments();
-    comments.setComments(Arrays.asList(comment1, comment2));
-    dataStore.put(comments);
+  void shouldAddTypeToPullRequestComments() throws IOException {
+    Path one = copyResource(store, "1");
 
     updateStep.doUpdate();
 
-    List<Comment> storedComments = dataStore.getAll().values().iterator().next().getComments();
-
-    assertThat(storedComments.size()).isEqualTo(2);
-    assertThat(storedComments.get(0).getType()).isEqualTo(CommentType.COMMENT);
-    assertThat(storedComments.get(0).getAuthor()).isEqualTo("trillian");
-    assertThat(storedComments.get(0).getComment()).isEqualTo("comment1");
-    assertThat(storedComments.get(1).getType()).isEqualTo(CommentType.COMMENT);
-    assertThat(storedComments.get(1).getAuthor()).isEqualTo("edi");
-    assertThat(storedComments.get(1).getComment()).isEqualTo("comment2");
+    PullRequestComments commentsOfOne = JAXB.unmarshal(one.toFile(), PullRequestComments.class);
+    assertThat(commentsOfOne.getComments())
+      .hasSize(4)
+      .extracting(Comment::getType)
+      .containsExactly(CommentType.COMMENT, CommentType.COMMENT, CommentType.COMMENT, CommentType.COMMENT);
   }
 
   @Test
-  void shouldSkipIfNoDataAvailable() {
+  void shouldNotOverwriteExistingTypeInPullRequestComments() throws IOException {
+    Path two = copyResource(store, "2");
+
     updateStep.doUpdate();
 
-    assertThat(dataStore.getAll().size()).isEqualTo(0);
+    PullRequestComments commentsOfTwo = JAXB.unmarshal(two.toFile(), PullRequestComments.class);
+    assertThat(commentsOfTwo.getComments())
+      .hasSize(3)
+      .extracting(Comment::getType)
+      .containsExactly(CommentType.COMMENT, CommentType.TASK_TODO, CommentType.TASK_DONE);
+  }
+
+  private Path createStore(Path temp) throws IOException {
+    Path store = temp.resolve("store").resolve("data").resolve("pullRequestComment");
+    Files.createDirectories(store);
+    return store;
+  }
+
+  private Path copyResource(Path store, String id) throws IOException {
+    String source = String.format("com/cloudogu/scm/review/update/comment-location-%s.xml", id);
+    URL resource = Resources.getResource(source);
+    Path target = store.resolve(id + ".xml");
+    try (OutputStream outputStream = Files.newOutputStream(target)) {
+      Resources.copy(resource, outputStream);
+    }
+    return target;
   }
 }
 

--- a/src/test/java/com/cloudogu/scm/review/update/AddTypeToCommentUpdateStepTest.java
+++ b/src/test/java/com/cloudogu/scm/review/update/AddTypeToCommentUpdateStepTest.java
@@ -65,6 +65,16 @@ class AddTypeToCommentUpdateStepTest {
   }
 
   @Test
+  void shouldNotAddTypeToCommentTextContentNode() throws IOException {
+    Path one = copyResource(store, "1");
+
+    updateStep.doUpdate();
+
+    PullRequestComments commentsOfOne = JAXB.unmarshal(one.toFile(), PullRequestComments.class);
+    assertThat(commentsOfOne.getComments().get(0).getComment()).isEqualTo("Don't panic!");
+  }
+
+  @Test
   void shouldNotOverwriteExistingTypeInPullRequestComments() throws IOException {
     Path two = copyResource(store, "2");
 

--- a/src/test/resources/com/cloudogu/scm/review/update/comment-location-1.xml
+++ b/src/test/resources/com/cloudogu/scm/review/update/comment-location-1.xml
@@ -6,7 +6,6 @@
     <author>sdorra</author>
     <date>1545306294752</date>
     <systemComment>false</systemComment>
-    <type>COMMENT</type>
     <replies>
       <id>9PRVoqF1tC</id>
       <comment>ok</comment>
@@ -32,7 +31,6 @@
     <author>fscholdei</author>
     <date>1549468553102</date>
     <systemComment>false</systemComment>
-    <type>COMMENT</type>
   </comment>
   <comment>
     <id>DCRKOarwU3</id>
@@ -57,7 +55,6 @@
       <hunk>@@ -1,3 +1,41 @@</hunk>
     </location>
     <systemComment>false</systemComment>
-    <type>TASK_DONE</type>
     <replies>
       <id>2PRX39IQK2</id>
       <comment>Hallo</comment>
@@ -82,7 +79,6 @@
       <hunk>@@ -1,3 +1,41 @@</hunk>
     </location>
     <systemComment>false</systemComment>
-    <type>COMMENT</type>
     <replies>
       <id>4dRTHKMXe6</id>
       <comment>Hallo?</comment>

--- a/src/test/resources/com/cloudogu/scm/review/update/comment-location-2.xml
+++ b/src/test/resources/com/cloudogu/scm/review/update/comment-location-2.xml
@@ -24,7 +24,7 @@
       <hunk>@@ -1,3 +1,41 @@</hunk>
     </location>
     <systemComment>false</systemComment>
-    <type>COMMENT</type>
+    <type>TASK_TODO</type>
   </comment>
   <comment>
     <id>3</id>
@@ -37,6 +37,6 @@
       <hunk>@@ -1,3 +1,41 @@</hunk>
     </location>
     <systemComment>false</systemComment>
-    <type>COMMENT</type>
+    <type>TASK_DONE</type>
   </comment>
 </pull-request-comments>


### PR DESCRIPTION
Without this, the changeId field for inline comments in legacy comment
data will be removed, because the new store type does not have this
field. Therefore the following update step migrating these changeIds to
line numbers has nothing to migrate, which will lead to errors in
displaying these comments.