### PR TITLE
Marking comments as outdated must not be guarded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- Comments are marked as outdated on commits without root permissions ([#49](https://github.com/scm-manager/scm-review-plugin/pull/49))
+
 ## 2.0.0-rc2 - 2020-01-29
 ### Added
 - Filter and sort function of the pull requests in the overview ([#19](https://github.com/scm-manager/scm-review-plugin/pull/19), [#21](https://github.com/scm-manager/scm-review-plugin/pull/21))

--- a/src/main/java/com/cloudogu/scm/review/comment/service/CommentService.java
+++ b/src/main/java/com/cloudogu/scm/review/comment/service/CommentService.java
@@ -95,7 +95,6 @@ public class CommentService {
 
   public void markAsOutdated(String namespace, String name, String pullRequestId, String commentId) {
     Repository repository = repositoryResolver.resolve(new NamespaceAndName(namespace, name));
-    PermissionCheck.checkComment(repository);
     Comment rootComment = findRootComment(repository, pullRequestId, commentId)
       .<NotFoundException>orElseThrow(() -> {
           throw notFound(entity(BasicComment.class, commentId)
@@ -104,7 +103,6 @@ public class CommentService {
         }
       );
 
-    PermissionCheck.checkModifyComment(repository, rootComment);
     if (!rootComment.isOutdated()) {
       rootComment.setOutdated(true);
       getCommentStore(repository).update(pullRequestId, rootComment);

--- a/src/test/java/com/cloudogu/scm/review/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/cloudogu/scm/review/comment/service/CommentServiceTest.java
@@ -455,7 +455,7 @@ public class CommentServiceTest {
   }
 
   @Test
-  @SubjectAware(username = "dent")
+  @SubjectAware(username = "trillian")
   public void shouldMarkCommentAsOutdated() {
     doNothing().when(store).update(eq(PULL_REQUEST_ID), rootCommentCaptor.capture());
 


### PR DESCRIPTION
## Proposed changes

This fixes a bug: The `FlagCommentsAsOutdatedHook` fails, when a user pushes a commit, but does not have permissions to modify comments of other users (which normally should be the case).

Marking comments as outdated does have nothing to do with editing
the comment. This will be done, whenever a new commit changes the
file of the comment (if this is not a global one).

Such commits require the 'push' permission. Having such a permission
does not imply, that the user does have the 'modify comments'
permission, too.

Besides this code is called from a hook only, not via rest endpoints.
This is only internal logic.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] PR is well described
- [x] Target branch is points not to master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [x] New code is covered with unit tests
- [x] CHANGELOG.md updated
- [ ] Documentation updated (only necessary for new features or changed behaviour)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
