### PR TITLE
loading indicator for workflow result statusbar

### DIFF
--- a/src/main/resources/locales/de/plugins.json
+++ b/src/main/resources/locales/de/plugins.json
@@ -298,7 +298,8 @@
         "rules_plural": "{{count}} Regeln definiert",
         "failedRules": "{{count}} Regel nicht erfüllt",
         "failedRules_plural": "{{count}} Regeln nicht erfüllt",
-        "noFailedRules": "Alle Regeln erfüllt"
+        "noFailedRules": "Alle Regeln erfüllt",
+        "loading": "Lade Workflow Engine Ergebnisse ..."
       },
       "modal": {
         "failedTitle": "{{count}} Regeln nicht erfüllt",

--- a/src/main/resources/locales/en/plugins.json
+++ b/src/main/resources/locales/en/plugins.json
@@ -295,7 +295,8 @@
         "rules_plural": "{{count}} rules",
         "failedRules": "{{count}} rule not fulfilled",
         "failedRules_plural": "{{count}} rules not fulfilled",
-        "noFailedRules": "All rules fulfilled"
+        "noFailedRules": "All rules fulfilled",
+        "loading": "Loading workflow engine results ..."
       },
       "modal": {
         "failedTitle": "{{count}} rule not fulfilled",

--- a/src/test/java/com/cloudogu/scm/review/pullrequest/api/PullRequestRootResourceTest.java
+++ b/src/test/java/com/cloudogu/scm/review/pullrequest/api/PullRequestRootResourceTest.java
@@ -38,6 +38,7 @@ import com.cloudogu.scm.review.pullrequest.service.PullRequestStatus;
 import com.cloudogu.scm.review.pullrequest.service.PullRequestStore;
 import com.cloudogu.scm.review.pullrequest.service.PullRequestStoreFactory;
 import com.cloudogu.scm.review.pullrequest.service.ReviewMark;
+import com.cloudogu.scm.review.workflow.Engine;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.sdorra.shiro.ShiroRule;
@@ -55,6 +56,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Answers;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -143,6 +145,8 @@ public class PullRequestRootResourceTest {
   private CommentService commentService;
   @Mock
   private ChannelRegistry channelRegistry;
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private Engine engine;
 
   @InjectMocks
   private PullRequestMapperImpl mapper;
@@ -166,6 +170,7 @@ public class PullRequestRootResourceTest {
     dispatcher.addSingletonResource(pullRequestRootResource);
     lenient().when(repositoryServiceFactory.create(any(Repository.class))).thenReturn(repositoryService);
     lenient().when(userDisplayManager.get("reviewer")).thenReturn(Optional.of(DisplayUser.from(new User("reviewer", "reviewer", ""))));
+    lenient().when(engine.configure(repository).getEngineConfiguration().isEnabled()).thenReturn(false);
   }
 
   @Test


### PR DESCRIPTION
## Proposed changes

This pr will append the workflow engine result link only to the pull request, if the workflow engine is enabled for the repository and the statusbar becomes a small loading indicator.

![Kapture 2020-04-24 at 7 36 30](https://user-images.githubusercontent.com/493333/80179512-04b0b400-8601-11ea-97c3-7f3bef3ea301.gif)

### Your checklist for this pull request

- [x] PR is well described
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
