### PR TITLE
Correctly reset workflow engine editor after adding a rule.

### DIFF
--- a/src/main/js/workflow/EngineConfigEditor.tsx
+++ b/src/main/js/workflow/EngineConfigEditor.tsx
@@ -144,6 +144,7 @@ const EngineConfigEditor: FC<Props> = ({ onConfigurationChange, initialConfigura
           helpText={t("scm-review-plugin.workflow.newRule.helpText")}
           onChange={selectRule}
           options={options}
+          value={selectedRule}
         />
       );
     }


### PR DESCRIPTION
## Proposed changes

The workflow engine editor did not correctly reset to its original state upon clicking the `Add Rule` button. This causes problems with adding the same rule multiple times and is now fixed.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] PR is well described
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [ ] New code is covered with unit tests
- [ ] CHANGELOG.md updated
- [ ] Documentation updated (only necessary for new features or changed behaviour)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
