### PR TITLE
Disable line comments on expanded hunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- Disable the possibility to add line comments to add line comments to expanded diff lines ([#83](https://github.com/scm-manager/scm-review-plugin/pull/83))
+
 ## 2.0.0 - 2020-06-04
 ### Added
 - New extension point for pull request details view

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Added
-- Disable the possibility to add line comments to add line comments to expanded diff lines ([#83](https://github.com/scm-manager/scm-review-plugin/pull/83))
+- Disable the possibility to add line comments to expanded diff lines ([#83](https://github.com/scm-manager/scm-review-plugin/pull/83))
 
 ## 2.0.0 - 2020-06-04
 ### Added

--- a/pom.xml
+++ b/pom.xml
@@ -73,21 +73,21 @@
     <dependency>
       <groupId>sonia.scm.plugins</groupId>
       <artifactId>scm-editor-plugin</artifactId>
-      <version>2.0.0-rc4</version>
+      <version>2.0.0</version>
       <optional>true</optional>
     </dependency>
 
     <dependency>
       <groupId>sonia.scm.plugins</groupId>
       <artifactId>scm-landingpage-plugin</artifactId>
-      <version>1.0.0-rc1</version>
+      <version>1.0.0</version>
       <optional>true</optional>
     </dependency>
 
     <dependency>
       <groupId>sonia.scm.plugins</groupId>
       <artifactId>scm-mail-plugin</artifactId>
-      <version>2.0.0-SNAPSHOT</version>
+      <version>2.0.0</version>
     </dependency>
 
     <dependency>
@@ -121,7 +121,7 @@
     <dependency>
       <groupId>sonia.scm</groupId>
       <artifactId>scm-dao-xml</artifactId>
-      <version>2.0.0-rc1</version>
+      <version>${project.parent.version}</version>
       <scope>provided</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
   <parent>
     <artifactId>scm-plugins</artifactId>
     <groupId>sonia.scm.plugins</groupId>
-    <version>2.0.0</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>scm-review-plugin</artifactId>

--- a/src/main/js/diff/Diff.tsx
+++ b/src/main/js/diff/Diff.tsx
@@ -110,7 +110,7 @@ class Diff extends React.Component<Props, State> {
           fileAnnotationFactory={this.fileAnnotationFactory}
           annotationFactory={this.annotationFactory}
           onClick={this.onGutterClick}
-          hunkClass={hunk => (hunk.expansion ? null : "commentable")}
+          hunkClass={hunk => (hunk.expansion ? "expanded" : "commentable")}
         />
       </StyledDiffWrapper>
     );

--- a/src/main/js/diff/Diff.tsx
+++ b/src/main/js/diff/Diff.tsx
@@ -110,6 +110,7 @@ class Diff extends React.Component<Props, State> {
           fileAnnotationFactory={this.fileAnnotationFactory}
           annotationFactory={this.annotationFactory}
           onClick={this.onGutterClick}
+          hunkClass={hunk => (hunk.expansion ? null : "commentable")}
         />
       </StyledDiffWrapper>
     );
@@ -195,7 +196,7 @@ class Diff extends React.Component<Props, State> {
   };
 
   onGutterClick = (context: DiffEventContext) => {
-    if (this.isPermittedToComment()) {
+    if (this.isPermittedToComment() && !context.hunk.expansion) {
       const location = createInlineLocation(context);
       this.openEditor(location);
     }

--- a/src/main/js/diff/StyledDiffWrapper.css
+++ b/src/main/js/diff/StyledDiffWrapper.css
@@ -26,3 +26,7 @@ tbody.commentable .diff-gutter:hover::after {
   content: " \f075";
   color: #33b2e8;
 }
+
+tbody.expanded .diff-gutter {
+  cursor: default;
+}

--- a/src/main/js/diff/StyledDiffWrapper.css
+++ b/src/main/js/diff/StyledDiffWrapper.css
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-div.commentable .diff-gutter:hover::after {
+tbody.commentable .diff-gutter:hover::after {
   font-family: "Font Awesome 5 Free";
   content: " \f075";
   color: #33b2e8;

--- a/src/main/js/diff/StyledDiffWrapper.tsx
+++ b/src/main/js/diff/StyledDiffWrapper.tsx
@@ -40,7 +40,7 @@ class StyledDiffWrapper extends Component<Props> {
   render() {
     const { children, commentable } = this.props;
     if (commentable) {
-      return <CommentableWrapper className="commentable">{children}</CommentableWrapper>;
+      return <CommentableWrapper>{children}</CommentableWrapper>;
     }
     return <div>{children}</div>;
   }


### PR DESCRIPTION
## Proposed changes

This adapts the review plugin to the new core feature to expand diffs introduced by https://github.com/scm-manager/scm-manager/pull/1178

This PR disables the possibliity to add line comments to such expanded lines.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] PR is well described
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [x] New code is covered with unit tests
- [ ] CHANGELOG.md updated
- [ ] Documentation updated (only necessary for new features or changed behaviour)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
