### PR TITLE
Extend CI permission to read pull requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Added
-- Sort mechanism for rules in "Add Rule" dropdown [#88](https://github.com/scm-manager/scm-review-plugin/pull/88)
-- Append source and target branch links to pull request [#87](https://github.com/scm-manager/scm-review-plugin/pull/87)
+- Sort mechanism for rules in "Add Rule" dropdown ([#88](https://github.com/scm-manager/scm-review-plugin/pull/88))
+- Append source and target branch links to pull request ([#87](https://github.com/scm-manager/scm-review-plugin/pull/87))
+- Extends permission role `CI-SERVER` with the permission to read pull requests ([#91](https://github.com/scm-manager/scm-review-plugin/pull/91))
 
 ## 2.2.0 - 2020-07-03
 ### Added
@@ -32,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rebuild for api changes from core
 
 ### Fixed
-- Exception on push in repository without merge support([#78](https://github.com/scm-manager/scm-review-plugin/pull/78))
+- Exception on push in repository without merge support ([#78](https://github.com/scm-manager/scm-review-plugin/pull/78))
 
 ## 2.0.0-rc9-3 - 2020-05-08
 ### Added

--- a/src/main/resources/META-INF/scm/repository-permissions.xml
+++ b/src/main/resources/META-INF/scm/repository-permissions.xml
@@ -51,5 +51,11 @@
         <verb>mergePullRequest</verb>
       </verbs>
     </role>
+    <role>
+      <name>CI-SERVER</name>
+      <verbs>
+        <verb>readPullRequest</verb>
+      </verbs>
+    </role>
   </roles>
 </repository-permissions>


### PR DESCRIPTION
To enable a jenkins with the scm-manager plugin to find
pull requests when the user configured in jenkins only has
the permission role 'CI-SERVER' we have to extend this
role to read pull requests, too. This has the downside,
that we will introduce this role if the CI plugin is not
installed, but we prefer this over a jenkins instance not
able to read pull requests.

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] PR is well described
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [x] CHANGELOG.md updated
- [x] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)
- [ ] Documentation updated (only necessary for new features or changed behaviour)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
