### PR TITLE
Bugfix: Check obstacles in pre commit hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Append source and target branch links to pull request ([#87](https://github.com/scm-manager/scm-review-plugin/pull/87))
 - Extends permission role `CI-SERVER` with the permission to read pull requests ([#91](https://github.com/scm-manager/scm-review-plugin/pull/91))
 
+### Fixed
+- Checks workflow engine and possible other rules for merges, when pull requests are merge by pushes ([#94](https://github.com/scm-manager/scm-review-plugin/pull/94))
+
 ## 2.2.0 - 2020-07-03
 ### Added
 - Use mail topics so users can unsubscribe from mails for specific events ([#85](https://github.com/scm-manager/scm-review-plugin/pull/85))

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
   <parent>
     <artifactId>scm-plugins</artifactId>
     <groupId>sonia.scm.plugins</groupId>
-    <version>2.3.0-SNAPSHOT</version>
+    <version>2.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>scm-review-plugin</artifactId>

--- a/src/main/java/com/cloudogu/scm/review/InternalMergeSwitch.java
+++ b/src/main/java/com/cloudogu/scm/review/InternalMergeSwitch.java
@@ -1,0 +1,46 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.cloudogu.scm.review;
+
+import javax.inject.Singleton;
+
+@Singleton
+public class InternalMergeSwitch {
+
+  private final ThreadLocal<Object> mergeRunning = new InheritableThreadLocal<>();
+
+  public void runInternalMerge(Runnable r) {
+    mergeRunning.set(new Object());
+    try {
+      r.run();
+    } finally {
+      mergeRunning.remove();
+    }
+  }
+
+  boolean internalMergeRunning() {
+    return mergeRunning.get() != null;
+  }
+}

--- a/src/main/java/com/cloudogu/scm/review/MergeObstacleCheckHook.java
+++ b/src/main/java/com/cloudogu/scm/review/MergeObstacleCheckHook.java
@@ -102,24 +102,24 @@ public class MergeObstacleCheckHook {
         try {
           Collection<MergeObstacle> mergeObstacles = mergeService.verifyNoObstacles(PermissionCheck.mayPerformEmergencyMerge(repository), repository, pullRequest);
           if (!mergeObstacles.isEmpty()) {
-            LOG.info("about to merge pull request #{} for repository {} with {} obstacles by push", pullRequest.getId(), repository.getNamespaceAndName(), mergeObstacles.size());
+            LOG.info("about to merge pull request #{} for repository {} with {} violated rule(s) by push", pullRequest.getId(), repository.getNamespaceAndName(), mergeObstacles.size());
             String[] message =
               {
-                format("This merges pull request #%s (%s -> %s) with %s obstacles.", pullRequest.getId(), pullRequest.getSource(), pullRequest.getTarget(), mergeObstacles.size()),
+                format("This merges pull request #%s (%s -> %s) with %s violated rule(s).", pullRequest.getId(), pullRequest.getSource(), pullRequest.getTarget(), mergeObstacles.size()),
                 "This merge is permitted only because you have the permission for emergency merges",
-                "or the obstacles are not blocking ones.",
+                "or the violated rules are not blocking ones.",
                 "Please check this pull request:"
               };
             messageSender.sendMessageForPullRequest(pullRequest, message);
           }
         } catch (MergeNotAllowedException e) {
           Collection<MergeObstacle> mergeObstacles = e.getObstacles();
-          LOG.debug("merge of pull request #{} for repository {} was rejected due to {} obstacle(s)", pullRequest.getId(), repository.getNamespaceAndName(), mergeObstacles.size());
+          LOG.debug("merge of pull request #{} for repository {} was rejected due to {} violated rule(s)", pullRequest.getId(), repository.getNamespaceAndName(), mergeObstacles.size());
           String[] message =
             {
-              format("This would merge pull request #%s (%s -> %s) with %s obstacle(s).", pullRequest.getId(), pullRequest.getSource(), pullRequest.getTarget(), mergeObstacles.size()),
+              format("This would merge pull request #%s (%s -> %s) with %s violated rule(s).", pullRequest.getId(), pullRequest.getSource(), pullRequest.getTarget(), mergeObstacles.size()),
               "You do not have the permission to execute emergency merges.",
-              "Please check this pull request for obstacles:"
+              "Please check this pull request for details about the rules:"
             };
           messageSender.sendMessageForPullRequest(pullRequest, message);
           throw e;

--- a/src/main/java/com/cloudogu/scm/review/MessageSender.java
+++ b/src/main/java/com/cloudogu/scm/review/MessageSender.java
@@ -33,9 +33,9 @@ import java.util.Arrays;
 
 public interface MessageSender {
 
-  void sendMessageForPullRequest(PullRequest pullRequest, String message);
+  void sendMessageForPullRequest(PullRequest pullRequest, String... message);
 
-  void sendCreatePullRequestMessage(String branch, String message);
+  void sendCreatePullRequestMessage(String branch, String... message);
 }
 
 class ProviderMessageSender implements MessageSender {
@@ -49,12 +49,12 @@ class ProviderMessageSender implements MessageSender {
   }
 
   @Override
-  public void sendMessageForPullRequest(PullRequest pullRequest, String message) {
+  public void sendMessageForPullRequest(PullRequest pullRequest, String... message) {
     sendMessages(message, createPullRequestLink(pullRequest));
   }
 
   @Override
-  public void sendCreatePullRequestMessage(String branch, String message) {
+  public void sendCreatePullRequestMessage(String branch, String... message) {
     sendMessages(message, createCreateLink(event.getRepository(), branch));
   }
 
@@ -77,10 +77,11 @@ class ProviderMessageSender implements MessageSender {
       pullRequest.getId());
   }
 
-  private void sendMessages(String... messages) {
+  private void sendMessages(String[] messages, String url) {
     HookMessageProvider messageProvider = event.getContext().getMessageProvider();
     messageProvider.sendMessage("");
     Arrays.stream(messages).forEach(messageProvider::sendMessage);
+    messageProvider.sendMessage(url);
     messageProvider.sendMessage("");
   }
 }
@@ -88,12 +89,12 @@ class ProviderMessageSender implements MessageSender {
 class NoOpMessageSender implements MessageSender {
 
   @Override
-  public void sendMessageForPullRequest(PullRequest pullRequest, String message) {
+  public void sendMessageForPullRequest(PullRequest pullRequest, String... message) {
     // no op implementation
   }
 
   @Override
-  public void sendCreatePullRequestMessage(String branch, String message) {
+  public void sendCreatePullRequestMessage(String branch, String... message) {
     // no op implementation
   }
 }

--- a/src/main/java/com/cloudogu/scm/review/MessageSender.java
+++ b/src/main/java/com/cloudogu/scm/review/MessageSender.java
@@ -25,8 +25,8 @@ package com.cloudogu.scm.review;
 
 import com.cloudogu.scm.review.pullrequest.service.PullRequest;
 import sonia.scm.config.ScmConfiguration;
-import sonia.scm.repository.PostReceiveRepositoryHookEvent;
 import sonia.scm.repository.Repository;
+import sonia.scm.repository.RepositoryHookEvent;
 import sonia.scm.repository.api.HookMessageProvider;
 
 import javax.inject.Inject;
@@ -37,10 +37,10 @@ import static sonia.scm.repository.api.HookFeature.MESSAGE_PROVIDER;
 public class MessageSender {
 
   private final ScmConfiguration configuration;
-  private final PostReceiveRepositoryHookEvent event;
+  private final RepositoryHookEvent event;
 
   @Inject
-  public MessageSender(ScmConfiguration configuration, PostReceiveRepositoryHookEvent event) {
+  public MessageSender(ScmConfiguration configuration, RepositoryHookEvent event) {
     this.configuration = configuration;
     this.event = event;
   }

--- a/src/main/java/com/cloudogu/scm/review/MessageSenderFactory.java
+++ b/src/main/java/com/cloudogu/scm/review/MessageSenderFactory.java
@@ -28,6 +28,8 @@ import sonia.scm.repository.RepositoryHookEvent;
 
 import javax.inject.Inject;
 
+import static sonia.scm.repository.api.HookFeature.MESSAGE_PROVIDER;
+
 public class MessageSenderFactory {
 
   private final ScmConfiguration configuration;
@@ -38,6 +40,10 @@ public class MessageSenderFactory {
   }
 
   public MessageSender create(RepositoryHookEvent event) {
-    return new MessageSender(configuration, event);
+    if (event.getContext().isFeatureSupported(MESSAGE_PROVIDER)) {
+      return new ProviderMessageSender(configuration, event);
+    } else {
+      return new NoOpMessageSender();
+    }
   }
 }

--- a/src/main/java/com/cloudogu/scm/review/MessageSenderFactory.java
+++ b/src/main/java/com/cloudogu/scm/review/MessageSenderFactory.java
@@ -24,7 +24,7 @@
 package com.cloudogu.scm.review;
 
 import sonia.scm.config.ScmConfiguration;
-import sonia.scm.repository.PostReceiveRepositoryHookEvent;
+import sonia.scm.repository.RepositoryHookEvent;
 
 import javax.inject.Inject;
 
@@ -37,7 +37,7 @@ public class MessageSenderFactory {
     this.configuration = configuration;
   }
 
-  public MessageSender create(PostReceiveRepositoryHookEvent event) {
+  public MessageSender create(RepositoryHookEvent event) {
     return new MessageSender(configuration, event);
   }
 }

--- a/src/main/java/com/cloudogu/scm/review/pullrequest/service/DefaultPullRequestService.java
+++ b/src/main/java/com/cloudogu/scm/review/pullrequest/service/DefaultPullRequestService.java
@@ -214,11 +214,10 @@ public class DefaultPullRequestService implements PullRequestService {
   }
 
   @Override
-  public void setMerged(Repository repository, String pullRequestId, String overrideMessage) {
+  public void setMerged(Repository repository, String pullRequestId) {
     PullRequest pullRequest = get(repository, pullRequestId);
     if (pullRequest.getStatus() == OPEN) {
       pullRequest.setStatus(MERGED);
-      pullRequest.setOverrideMessage(overrideMessage);
       getStore(repository).update(pullRequest);
       eventBus.post(new PullRequestMergedEvent(repository, pullRequest));
     } else if (pullRequest.getStatus() == REJECTED) {

--- a/src/main/java/com/cloudogu/scm/review/pullrequest/service/MergeNotAllowedException.java
+++ b/src/main/java/com/cloudogu/scm/review/pullrequest/service/MergeNotAllowedException.java
@@ -30,9 +30,19 @@ import sonia.scm.repository.Repository;
 import java.util.Collection;
 import java.util.stream.Collectors;
 
+import static java.util.Collections.unmodifiableCollection;
+
 public class MergeNotAllowedException extends ExceptionWithContext {
+
+  private final Collection<MergeObstacle> obstacles;
+
   public MergeNotAllowedException(Repository repository, PullRequest pullRequest, Collection<MergeObstacle> obstacles) {
     super(ContextEntry.ContextBuilder.entity(PullRequest.class, pullRequest.getId()).in(repository).build(), buildMessage(obstacles));
+    this.obstacles = obstacles;
+  }
+
+  public Collection<MergeObstacle> getObstacles() {
+    return unmodifiableCollection(obstacles);
   }
 
   private static String buildMessage(Collection<MergeObstacle> obstacles) {

--- a/src/main/java/com/cloudogu/scm/review/pullrequest/service/PullRequestService.java
+++ b/src/main/java/com/cloudogu/scm/review/pullrequest/service/PullRequestService.java
@@ -104,7 +104,7 @@ public interface PullRequestService {
 
   void setRevisions(Repository repository, String id, String targetRevision, String revisionToMerge);
 
-  void setMerged(Repository repository, String pullRequestId, String overrideMessage);
+  void setMerged(Repository repository, String pullRequestId);
 
   void setEmergencyMerged(Repository repository, String pullRequestId, String overrideMessage, List<String> ignoredMergeObstacles);
 

--- a/src/test/java/com/cloudogu/scm/review/MergeObstacleCheckHookTest.java
+++ b/src/test/java/com/cloudogu/scm/review/MergeObstacleCheckHookTest.java
@@ -1,0 +1,220 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.cloudogu.scm.review;
+
+import com.cloudogu.scm.review.pullrequest.service.DefaultPullRequestService;
+import com.cloudogu.scm.review.pullrequest.service.MergeNotAllowedException;
+import com.cloudogu.scm.review.pullrequest.service.MergeObstacle;
+import com.cloudogu.scm.review.pullrequest.service.MergeService;
+import com.cloudogu.scm.review.pullrequest.service.PullRequest;
+import com.cloudogu.scm.review.pullrequest.service.PullRequestStatus;
+import org.apache.shiro.subject.Subject;
+import org.apache.shiro.util.ThreadContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import sonia.scm.repository.PreReceiveRepositoryHookEvent;
+import sonia.scm.repository.Repository;
+import sonia.scm.repository.api.HookBranchProvider;
+import sonia.scm.repository.api.HookContext;
+import sonia.scm.repository.api.HookMessageProvider;
+import sonia.scm.repository.spi.HookMergeDetectionProvider;
+
+import static java.util.Collections.singletonList;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static sonia.scm.repository.api.HookFeature.BRANCH_PROVIDER;
+import static sonia.scm.repository.api.HookFeature.MERGE_DETECTION_PROVIDER;
+import static sonia.scm.repository.api.HookFeature.MESSAGE_PROVIDER;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class MergeObstacleCheckHookTest {
+
+  private static final String NAMESPACE = "space";
+  private static final String NAME = "name";
+  private static final Repository REPOSITORY = new Repository("id", "git", NAMESPACE, NAME);
+
+  @Mock
+  private DefaultPullRequestService pullRequestService;
+  @Mock
+  private MergeService mergeService;
+
+  private MergeObstacleCheckHook hook;
+
+  @Mock
+  private PreReceiveRepositoryHookEvent event;
+  @Mock
+  private HookContext hookContext;
+  @Mock
+  private HookMergeDetectionProvider mergeDetectionProvider;
+  @Mock
+  private HookMessageProvider messageProvider;
+  @Mock
+  private HookBranchProvider branchProvider;
+  @Captor
+  private ArgumentCaptor<String> messageCaptor;
+
+  @Mock
+  private Subject subject;
+
+  @BeforeEach
+  void initBasics() {
+    hook = new MergeObstacleCheckHook(pullRequestService, mergeService);
+    when(pullRequestService.supportsPullRequests(REPOSITORY)).thenReturn(true);
+    when(hookContext.isFeatureSupported(MERGE_DETECTION_PROVIDER)).thenReturn(true);
+    when(hookContext.getMergeDetectionProvider()).thenReturn(mergeDetectionProvider);
+    when(hookContext.isFeatureSupported(BRANCH_PROVIDER)).thenReturn(true);
+    when(hookContext.getBranchProvider()).thenReturn(branchProvider);
+    when(hookContext.isFeatureSupported(MESSAGE_PROVIDER)).thenReturn(true);
+    when(hookContext.getMessageProvider()).thenReturn(messageProvider);
+    doNothing().when(messageProvider).sendMessage(messageCaptor.capture());
+  }
+
+  @BeforeEach
+  void initEvent() {
+    when(event.getContext()).thenReturn(hookContext);
+  }
+
+  @BeforeEach
+  void initRepository() {
+    when(event.getRepository()).thenReturn(REPOSITORY);
+  }
+
+  @BeforeEach
+  void mockSubject() {
+    ThreadContext.bind(subject);
+  }
+
+  @AfterEach
+  void cleanupSubject() {
+    ThreadContext.unbindSubject();
+  }
+
+  @Nested
+  class WithOpenPullRequest {
+
+    PullRequest pullRequest;
+
+    @BeforeEach
+    void mockChangedBranch() {
+      when(branchProvider.getCreatedOrModified()).thenReturn(singletonList("target"));
+    }
+
+    @BeforeEach
+    void mockPullRequest() {
+      pullRequest = new PullRequest("pr", "source", "target");
+      pullRequest.setStatus(PullRequestStatus.OPEN);
+      when(pullRequestService.getAll(NAMESPACE, NAME)).thenReturn(singletonList(pullRequest));
+
+      doReturn(singletonList(new TestObstacle()))
+        .when(mergeService).verifyNoObstacles(true, REPOSITORY, pullRequest);
+      doThrow(new MergeNotAllowedException(REPOSITORY, pullRequest, singletonList(new TestObstacle())))
+        .when(mergeService).verifyNoObstacles(false, REPOSITORY, pullRequest);
+    }
+
+    @Nested
+    class WithEmergencyPermission {
+
+      @BeforeEach
+      void mockPermission() {
+        when(subject.isPermitted("repository:performEmergencyMerge:id")).thenReturn(true);
+      }
+
+      @Test
+      void shouldPassByMergeOfPullRequests() {
+        when(mergeDetectionProvider.branchesMerged("target", "source")).thenReturn(true);
+
+        hook.checkForObstacles(event);
+
+        // nothing more expected to happen
+      }
+    }
+
+    @Nested
+    class WithoutEmergencyPermission {
+
+      @BeforeEach
+      void mockPermission() {
+        when(subject.isPermitted("repository:performEmergencyMerge:id")).thenReturn(false);
+      }
+
+      @Test
+      void shouldRejectToMergePullRequestsWithObstacles() {
+        when(mergeDetectionProvider.branchesMerged("target", "source")).thenReturn(true);
+
+        Assertions.assertThrows(MergeNotAllowedException.class, () -> hook.checkForObstacles(event));
+      }
+    }
+
+    @Test
+    void shouldIgnoreChangeOfIrrelevantBranch() {
+      when(branchProvider.getCreatedOrModified()).thenReturn(singletonList("other"));
+
+      hook.checkForObstacles(event);
+
+      verify(mergeDetectionProvider, never()).branchesMerged(any(), any());
+    }
+  }
+
+  @Test
+  void shouldIgnoreClosedPullRequest() {
+    PullRequest pullRequest = new PullRequest("pr", "source", "target");
+    pullRequest.setStatus(PullRequestStatus.REJECTED);
+    when(pullRequestService.getAll(NAMESPACE, NAME)).thenReturn(singletonList(pullRequest));
+
+    when(branchProvider.getCreatedOrModified()).thenReturn(singletonList("source"));
+
+    hook.checkForObstacles(event);
+
+    verify(branchProvider, never()).getCreatedOrModified();
+    verify(mergeDetectionProvider, never()).branchesMerged(any(), any());
+  }
+
+  private static class TestObstacle implements MergeObstacle {
+    @Override
+    public String getMessage() {
+      return null;
+    }
+
+    @Override
+    public String getKey() {
+      return null;
+    }
+  }
+}

--- a/src/test/java/com/cloudogu/scm/review/MergeObstacleCheckHookTest.java
+++ b/src/test/java/com/cloudogu/scm/review/MergeObstacleCheckHookTest.java
@@ -92,13 +92,15 @@ class MergeObstacleCheckHookTest {
   private HookMessageProvider messageProvider;
   @Mock
   private HookBranchProvider branchProvider;
+  @Mock
+  private InternalMergeSwitch internalMergeSwitch;
 
   @Mock
   private Subject subject;
 
   @BeforeEach
   void initBasics() {
-    hook = new MergeObstacleCheckHook(pullRequestService, mergeService, messageSenderFactory);
+    hook = new MergeObstacleCheckHook(pullRequestService, mergeService, messageSenderFactory, internalMergeSwitch);
     when(pullRequestService.supportsPullRequests(REPOSITORY)).thenReturn(true);
     when(configuration.getBaseUrl()).thenReturn("http://example.com/");
     when(hookContext.isFeatureSupported(MERGE_DETECTION_PROVIDER)).thenReturn(true);
@@ -175,6 +177,16 @@ class MergeObstacleCheckHookTest {
         hook.checkForObstacles(event);
 
         verify(messageProvider, atLeastOnce()).sendMessage(any());
+      }
+
+      @Test
+      void shouldNotCheckForInternalMerge() {
+        when(internalMergeSwitch.internalMergeRunning()).thenReturn(true);
+
+        hook.checkForObstacles(event);
+
+        verify(mergeDetectionProvider, never()).branchesMerged(any(), any());
+        verify(messageProvider, never()).sendMessage(any());
       }
     }
 

--- a/src/test/java/com/cloudogu/scm/review/StatusCheckHookTest.java
+++ b/src/test/java/com/cloudogu/scm/review/StatusCheckHookTest.java
@@ -30,8 +30,6 @@ import com.cloudogu.scm.review.pullrequest.service.PullRequestStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -50,7 +48,6 @@ import static java.util.Collections.singletonList;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -86,8 +83,6 @@ class StatusCheckHookTest {
   private HookMessageProvider messageProvider;
   @Mock
   private HookBranchProvider branchProvider;
-  @Captor
-  private ArgumentCaptor<String> messageCaptor;
 
   @BeforeEach
   void initBasics() {
@@ -100,7 +95,6 @@ class StatusCheckHookTest {
     when(hookContext.getBranchProvider()).thenReturn(branchProvider);
     when(hookContext.isFeatureSupported(MESSAGE_PROVIDER)).thenReturn(true);
     when(hookContext.getMessageProvider()).thenReturn(messageProvider);
-    doNothing().when(messageProvider).sendMessage(messageCaptor.capture());
   }
 
   @BeforeEach

--- a/src/test/java/com/cloudogu/scm/review/pullrequest/service/DefaultPullRequestServiceTest.java
+++ b/src/test/java/com/cloudogu/scm/review/pullrequest/service/DefaultPullRequestServiceTest.java
@@ -453,7 +453,7 @@ class DefaultPullRequestServiceTest {
       service.setRejected(REPOSITORY, pullRequest.getId(), REJECTED_BY_USER);
 
       assertThat(pullRequest.getStatus()).isEqualTo(REJECTED);
-      assertThat(eventCaptor.getAllValues()).hasSize(0);
+      assertThat(eventCaptor.getAllValues()).isEmpty();
     }
 
     @Test
@@ -463,17 +463,16 @@ class DefaultPullRequestServiceTest {
       assertThrows(StatusChangeNotAllowedException.class, () -> service.setRejected(REPOSITORY, pullRequest.getId(), REJECTED_BY_USER));
 
       assertThat(pullRequest.getStatus()).isEqualTo(MERGED);
-      assertThat(eventCaptor.getAllValues()).hasSize(0);
+      assertThat(eventCaptor.getAllValues()).isEmpty();
     }
 
     @Test
     void shouldSetPullRequestMergedAndSendEvent() {
       pullRequest.setStatus(OPEN);
 
-      service.setMerged(REPOSITORY, pullRequest.getId(), "had to be this way");
+      service.setMerged(REPOSITORY, pullRequest.getId());
 
       assertThat(pullRequest.getStatus()).isEqualTo(MERGED);
-      assertThat(pullRequest.getOverrideMessage()).isEqualTo("had to be this way");
       assertThat(eventCaptor.getAllValues()).hasSize(1);
       PullRequestMergedEvent event = (PullRequestMergedEvent) eventCaptor.getValue();
       assertThat(event.getRepository()).isSameAs(REPOSITORY);
@@ -484,20 +483,20 @@ class DefaultPullRequestServiceTest {
     void shouldNotSetPullRequestMergedMultipleTimes() {
       pullRequest.setStatus(MERGED);
 
-      service.setMerged(REPOSITORY, pullRequest.getId(), null);
+      service.setMerged(REPOSITORY, pullRequest.getId());
 
       assertThat(pullRequest.getStatus()).isEqualTo(MERGED);
-      assertThat(eventCaptor.getAllValues()).hasSize(0);
+      assertThat(eventCaptor.getAllValues()).isEmpty();
     }
 
     @Test
     void shouldNotSetRejectedPullRequestMerged() {
       pullRequest.setStatus(REJECTED);
 
-      assertThrows(StatusChangeNotAllowedException.class, () -> service.setMerged(REPOSITORY, pullRequest.getId(), null));
+      assertThrows(StatusChangeNotAllowedException.class, () -> service.setMerged(REPOSITORY, pullRequest.getId()));
 
       assertThat(pullRequest.getStatus()).isEqualTo(REJECTED);
-      assertThat(eventCaptor.getAllValues()).hasSize(0);
+      assertThat(eventCaptor.getAllValues()).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes

Checks for the existance of obstacles from the workflow engine or other sources when a merge is detected in a pre commit hook.
If such obstacles exist, the push is rejected due to the rules of these obstacles. If the user has the permission for "emergency merges", a message is sent to the user through the protocol.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] PR is well described
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [x] New code is covered with unit tests
- [x] CHANGELOG.md updated
- [x] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
