### PR TITLE
Use fallback mail address when user has none

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- Handle users without an email address ([#101](https://github.com/scm-manager/scm-review-plugin/pull/101/files))
+
 ## 2.4.0 - 2020-09-25
 ### Added
 - Add support for pr merge with prior rebase ([#99](https://github.com/scm-manager/scm-review-plugin/pull/99))

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
   <parent>
     <artifactId>scm-plugins</artifactId>
     <groupId>sonia.scm.plugins</groupId>
-    <version>2.6.0</version>
+    <version>2.8.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>scm-review-plugin</artifactId>

--- a/src/main/java/com/cloudogu/scm/review/pullrequest/dto/PullRequestMapper.java
+++ b/src/main/java/com/cloudogu/scm/review/pullrequest/dto/PullRequestMapper.java
@@ -190,7 +190,7 @@ public abstract class PullRequestMapper extends BaseMapper<PullRequest, PullRequ
       .all(namespace, name, pullRequestId)));
     linksBuilder.single(link("events", pullRequestResourceLinks.pullRequest()
       .events(namespace, name, pullRequestId)));
-    if (PermissionCheck.mayComment(repository) && CurrentUserResolver.getCurrentUser() != null && !Strings.isNullOrEmpty(CurrentUserResolver.getCurrentUser().getMail())) {
+    if (PermissionCheck.mayComment(repository) && CurrentUserResolver.getCurrentUser() != null) {
       if (pullRequest.getStatus() == PullRequestStatus.OPEN) {
         if (pullRequestService.hasUserApproved(repository, pullRequest.getId())) {
           linksBuilder.single(link("disapprove", pullRequestResourceLinks.pullRequest().disapprove(namespace, name, pullRequestId)));
@@ -199,8 +199,10 @@ public abstract class PullRequestMapper extends BaseMapper<PullRequest, PullRequ
         }
       }
 
-      linksBuilder.single(link("subscription", pullRequestResourceLinks.pullRequest()
-        .subscription(namespace, name, pullRequestId)));
+      if (!Strings.isNullOrEmpty(CurrentUserResolver.getCurrentUser().getMail())) {
+        linksBuilder.single(link("subscription", pullRequestResourceLinks.pullRequest()
+          .subscription(namespace, name, pullRequestId)));
+      }
     }
     if (PermissionCheck.mayModifyPullRequest(repository, pullRequest)) {
       linksBuilder.single(link("update", pullRequestResourceLinks.pullRequest()

--- a/src/main/js/MergeForm.tsx
+++ b/src/main/js/MergeForm.tsx
@@ -25,7 +25,7 @@ import React from "react";
 import { WithTranslation, withTranslation } from "react-i18next";
 import { Link } from "@scm-manager/ui-types";
 import MergeStrategies from "./MergeStrategies";
-import { Button, Checkbox, Textarea } from "@scm-manager/ui-components";
+import { Button, Checkbox, CommitAuthor, Textarea } from "@scm-manager/ui-components";
 import styled from "styled-components";
 
 type Props = WithTranslation & {
@@ -44,6 +44,10 @@ type Props = WithTranslation & {
 
 const CommitMessageInfo = styled.div`
   margin-bottom: 1em;
+`;
+
+const MarginBottom = styled.div`
+  margin-bottom: 0.5rem;
 `;
 
 class MergeForm extends React.Component<Props> {
@@ -89,6 +93,9 @@ class MergeForm extends React.Component<Props> {
             <span>{t("scm-review-plugin.showPullRequest.mergeModal.commitMessageHint." + commitMessageHint)}</span>
           </CommitMessageInfo>
         )}
+        <MarginBottom>
+          <CommitAuthor />
+        </MarginBottom>
         <Button label={t("scm-review-plugin.showPullRequest.mergeModal.resetMessage")} action={onResetCommitMessage} />
         <hr />
       </>


### PR DESCRIPTION
## Proposed changes

Uses the new fallback mail for "Me" for a merge. Replaces #100 

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] PR is well described
- [x] Related issues linked to PR if existing and labels set
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [x] New code is covered with unit tests
- [x] CHANGELOG.md updated
- [x] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)
- [ ] Documentation updated (only necessary for new features or changed behaviour)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
