### PR TITLE
Prevents branch pr table from overlapping with navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- Prevents branch pr table from overlapping with navigation ([#121](https://github.com/scm-manager/scm-review-plugin/pull/121))
+
 ## 2.6.2 - 2021-01-29
 ### Fixed
 - Wrap long branch names in PR overview table ([#118](https://github.com/scm-manager/scm-review-plugin/pull/118))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
-### Fixed
-- Prevents branch pr table from overlapping with navigation ([#121](https://github.com/scm-manager/scm-review-plugin/pull/121))
-
 ## 2.6.2 - 2021-01-29
 ### Fixed
 - Wrap long branch names in PR overview table ([#118](https://github.com/scm-manager/scm-review-plugin/pull/118))

--- a/gradle/changelog/branch_pr_table_overview.yaml
+++ b/gradle/changelog/branch_pr_table_overview.yaml
@@ -1,0 +1,3 @@
+- type: fixed
+  description: Prevents branch pr table from overlapping with navigation ([#121](https://github.com/scm-manager/scm-review-plugin/pull/121))
+

--- a/gradle/changelog/branch_pr_table_overview.yaml
+++ b/gradle/changelog/branch_pr_table_overview.yaml
@@ -1,3 +1,0 @@
-- type: fixed
-  description: Prevents branch pr table from overlapping with navigation ([#121](https://github.com/scm-manager/scm-review-plugin/pull/121))
-

--- a/src/main/js/CreatePullRequestButton.tsx
+++ b/src/main/js/CreatePullRequestButton.tsx
@@ -45,6 +45,10 @@ const HR = styled.hr`
   height: 3px;
 `;
 
+const ScrollingTable = styled.div`
+  overflow-x: auto;
+`;
+
 class CreatePullRequestButton extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
@@ -100,9 +104,9 @@ class CreatePullRequestButton extends React.Component<Props, State> {
     let existing = null;
     if (matchingPullRequests.length > 0) {
       existing = (
-        <div>
+        <ScrollingTable className="mb-3">
           <PullRequestTable repository={repository} pullRequests={matchingPullRequests} />
-        </div>
+        </ScrollingTable>
       );
     }
     return (


### PR DESCRIPTION
## Proposed changes

Prevents branch pr table from overlapping with navigation

### Your checklist for this pull request

- [x] PR is well described and the description can be used as commit message on squash
- [ ] Related issues linked to PR if existing and labels set
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [ ] New code is covered with unit tests
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [x] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)
- [ ] Documentation updated (only necessary for new features or changed behaviour)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
