### PR TITLE
add extension points for markdown ast plugins to pr description & comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# Unreleased
+### Added
+- add extension points for markdown ast plugins to pr description & comments ([#122](https://github.com/scm-manager/scm-review-plugin/pull/122))
+
 ## 2.6.3 - 2021-03-01
 ### Fixed
 - Prevents branch pr table from overlapping with navigation ([#121](https://github.com/scm-manager/scm-review-plugin/pull/121))

--- a/build.gradle
+++ b/build.gradle
@@ -33,10 +33,11 @@ dependencies {
   optionalPlugin "sonia.scm.plugins:scm-landingpage-plugin:1.0.0"
   testImplementation "com.github.spullara.mustache.java:compiler:0.9.7"
   testImplementation "javax.el:javax.el-api:3.0.1-b06"
+  testImplementation "com.github.sdorra:shiro-unit:1.0.1"
 }
 
 scmPlugin {
-  scmVersion = "2.8.0"
+  scmVersion = "2.14.2-SNAPSHOT"
   displayName = "Review"
   description = "Depict a review process with pull requests"
   author = "Cloudogu GmbH"

--- a/build.gradle
+++ b/build.gradle
@@ -1,18 +1,18 @@
 /*
  * MIT License
- * 
+ *
  * Copyright (c) 2020-present Cloudogu GmbH and Contributors
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -32,8 +32,13 @@ dependencies {
   optionalPlugin "sonia.scm.plugins:scm-editor-plugin:2.0.0"
   optionalPlugin "sonia.scm.plugins:scm-landingpage-plugin:1.0.0"
   testImplementation "com.github.spullara.mustache.java:compiler:0.9.7"
-  testImplementation "javax.el:javax.el-api:3.0.1-b06"
+
   testImplementation "com.github.sdorra:shiro-unit:1.0.1"
+
+  testImplementation "org.jboss.resteasy:resteasy-validator-provider:4.5.8.Final"
+  testImplementation "org.hibernate.validator:hibernate-validator:6.1.6.Final"
+  testImplementation "javax.el:javax.el-api:3.0.0"
+  testImplementation "org.glassfish:javax.el:3.0.1-b11"
 }
 
 scmPlugin {

--- a/src/main/java/com/cloudogu/scm/review/comment/api/CommentMapper.java
+++ b/src/main/java/com/cloudogu/scm/review/comment/api/CommentMapper.java
@@ -30,22 +30,22 @@ import com.cloudogu.scm.review.comment.service.CommentType;
 import com.cloudogu.scm.review.comment.service.ContextLine;
 import com.cloudogu.scm.review.pullrequest.dto.BranchRevisionResolver;
 import com.cloudogu.scm.review.pullrequest.dto.DisplayedUserDto;
-import com.google.common.base.Strings;
-import de.otto.edison.hal.HalRepresentation;
+import de.otto.edison.hal.Embedded;
 import de.otto.edison.hal.Links;
 import org.mapstruct.AfterMapping;
 import org.mapstruct.Context;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
+import sonia.scm.api.v2.resources.HalAppenderMapper;
 import sonia.scm.repository.Repository;
 import sonia.scm.user.DisplayUser;
 import sonia.scm.user.UserDisplayManager;
+import sonia.scm.web.EdisonHalAppender;
 
 import javax.inject.Inject;
 import javax.inject.Named;
 import java.util.Collection;
-import java.util.List;
 import java.util.OptionalInt;
 import java.util.Set;
 
@@ -53,7 +53,7 @@ import static de.otto.edison.hal.Link.link;
 import static java.util.stream.Collectors.toList;
 
 @Mapper
-public abstract class CommentMapper {
+public abstract class CommentMapper extends HalAppenderMapper {
 
   @Inject
   private UserDisplayManager userDisplayManager;
@@ -106,6 +106,8 @@ public abstract class CommentMapper {
         linksBuilder.single(link("delete", commentPathBuilder.createDeleteCommentUri(namespace, name, pullRequestId, target.getId(), revisions)));
       }
     }
+    applyEnrichers(new EdisonHalAppender(linksBuilder, new Embedded.Builder()), source, repository);
+
     target.add(linksBuilder.build());
   }
 

--- a/src/main/java/com/cloudogu/scm/review/comment/api/ReplyMapper.java
+++ b/src/main/java/com/cloudogu/scm/review/comment/api/ReplyMapper.java
@@ -28,26 +28,27 @@ import com.cloudogu.scm.review.comment.service.Comment;
 import com.cloudogu.scm.review.comment.service.Reply;
 import com.cloudogu.scm.review.pullrequest.dto.BranchRevisionResolver;
 import com.cloudogu.scm.review.pullrequest.dto.DisplayedUserDto;
-import com.google.common.base.Strings;
+import de.otto.edison.hal.Embedded;
 import de.otto.edison.hal.Links;
 import org.mapstruct.AfterMapping;
 import org.mapstruct.Context;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
+import sonia.scm.api.v2.resources.HalAppenderMapper;
 import sonia.scm.repository.Repository;
 import sonia.scm.user.DisplayUser;
 import sonia.scm.user.UserDisplayManager;
+import sonia.scm.web.EdisonHalAppender;
 
 import javax.inject.Inject;
 import javax.inject.Named;
-
 import java.util.Set;
 
 import static de.otto.edison.hal.Link.link;
 
 @Mapper
-public abstract class ReplyMapper {
+public abstract class ReplyMapper extends HalAppenderMapper {
 
   @Inject
   private UserDisplayManager userDisplayManager;
@@ -87,6 +88,7 @@ public abstract class ReplyMapper {
       linksBuilder.single(link("update", commentPathBuilder.createUpdateReplyUri(namespace, name, pullRequestId, comment.getId(), target.getId(), revisions)));
       linksBuilder.single(link("delete", commentPathBuilder.createDeleteReplyUri(namespace, name, pullRequestId, comment.getId(), target.getId(), revisions)));
     }
+    applyEnrichers(new EdisonHalAppender(linksBuilder, new Embedded.Builder()), source, repository);
     target.add(linksBuilder.build());
   }
 

--- a/src/main/js/PullRequestDetails.tsx
+++ b/src/main/js/PullRequestDetails.tsx
@@ -26,8 +26,9 @@ import styled from "styled-components";
 import { WithTranslation, withTranslation } from "react-i18next";
 import { RouteComponentProps, withRouter } from "react-router-dom";
 import { Link, Repository } from "@scm-manager/ui-types";
-import { ExtensionPoint } from "@scm-manager/ui-extensions";
+import { binder, ExtensionPoint } from "@scm-manager/ui-extensions";
 import {
+  AstPlugin,
   Button,
   ButtonGroup,
   ConflictError,
@@ -191,7 +192,7 @@ class PullRequestDetails extends React.Component<Props, State> {
     this.setState({
       mergeCheck: undefined
     });
-  }
+  };
 
   getMergeDryRun(pullRequest: PullRequest) {
     if (this.shouldRunDryMerge(pullRequest)) {
@@ -303,7 +304,14 @@ class PullRequestDetails extends React.Component<Props, State> {
       description = (
         <div className="media">
           <MediaContent>
-            <ReducedMarkdownView content={pullRequest.description} />
+            <ReducedMarkdownView
+              content={pullRequest.description}
+              plugins={binder
+                .getExtensions("pullrequest.description.plugins", {
+                  halObject: pullRequest
+                })
+                .map(pluginFactory => pluginFactory({ halObject: pullRequest }) as AstPlugin)}
+            />
           </MediaContent>
         </div>
       );

--- a/src/main/js/ReducedMarkdownView.tsx
+++ b/src/main/js/ReducedMarkdownView.tsx
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 import React, { FC } from "react";
-import { MarkdownView } from "@scm-manager/ui-components";
+import { AstPlugin, MarkdownView } from "@scm-manager/ui-components";
 import styled from "styled-components";
 
 const MarkdownWrapper = styled.div`
@@ -56,12 +56,13 @@ const MarkdownWrapper = styled.div`
 
 type Props = {
   content: string;
+  plugins?: AstPlugin[];
 };
 
-const ReducedMarkdownView: FC<Props> = ({ content }) => {
+const ReducedMarkdownView: FC<Props> = ({ content, plugins = [] }) => {
   return (
     <MarkdownWrapper>
-      <MarkdownView content={content} />
+      <MarkdownView content={content} mdastPlugins={plugins} />
     </MarkdownWrapper>
   );
 };

--- a/src/main/js/comment/CommentContent.tsx
+++ b/src/main/js/comment/CommentContent.tsx
@@ -25,6 +25,8 @@ import React, { FC, useEffect, useState } from "react";
 import { Comment } from "../types/PullRequest";
 import { useTranslation } from "react-i18next";
 import ReducedMarkdownView from "../ReducedMarkdownView";
+import { binder } from "@scm-manager/ui-extensions";
+import { AstPlugin } from "@scm-manager/ui-components";
 
 type Props = {
   comment: Comment;
@@ -44,7 +46,16 @@ const CommentContent: FC<Props> = ({ comment }) => {
     setMessage(content);
   }, [comment]);
 
-  return <ReducedMarkdownView content={message} />;
+  return (
+    <ReducedMarkdownView
+      content={message}
+      plugins={binder
+        .getExtensions("pullrequest.comment.plugins", {
+          halObject: comment
+        })
+        .map(pluginFactory => pluginFactory({ halObject: comment }) as AstPlugin)}
+    />
+  );
 };
 
 export default CommentContent;


### PR DESCRIPTION
## Proposed changes

Two new extension points have been created to allow depending plugins to implement custom markdown ast plugins that change the output of pr descriptions and/or comments. This feature was primarily added for the issue-tracker-plugin to replace issue id keywords with http links to the actual issue.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] PR is well described and the description can be used as commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [ ] New code is covered with unit tests
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)
- [ ] Documentation updated (only necessary for new features or changed behaviour)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
