### PR TITLE
fix outdated tag without context being displayed as clickable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Fixed
 - Path for open api spec ([#123](https://github.com/scm-manager/scm-review-plugin/pull/123))
+- fix outdated tag without context being displayed as clickable ([#125](https://github.com/scm-manager/scm-review-plugin/pull/125))
 
 # 2.7.0 - 2021-03-12
 ### Added

--- a/src/main/js/comment/CommentTags.tsx
+++ b/src/main/js/comment/CommentTags.tsx
@@ -23,14 +23,14 @@
  */
 import React, { FC } from "react";
 import { Comment } from "../types/PullRequest";
-import {EmergencyMergeTag, FileTag, OutdatedTag, SystemTag, TaskDoneTag, TaskTodoTag} from "./tags";
+import { EmergencyMergeTag, FileTag, OutdatedTag, SystemTag, TaskDoneTag, TaskTodoTag } from "./tags";
 import { useTranslation } from "react-i18next";
 import TagGroup from "./TagGroup";
 import { findLatestTransition } from "./transitions";
 
 type Props = {
   comment: Comment;
-  onOpenContext: () => void;
+  onOpenContext?: () => void;
 };
 
 const CommentTags: FC<Props> = ({ comment, onOpenContext }) => {
@@ -51,7 +51,7 @@ const CommentTags: FC<Props> = ({ comment, onOpenContext }) => {
   }
 
   if (comment.emergencyMerged) {
-    tags.push(<EmergencyMergeTag/>)
+    tags.push(<EmergencyMergeTag />);
   }
 
   if (comment.type === "TASK_TODO") {

--- a/src/main/js/comment/PullRequestComment.tsx
+++ b/src/main/js/comment/PullRequestComment.tsx
@@ -344,7 +344,7 @@ class PullRequestComment extends React.Component<Props, State> {
   };
 
   collectTags = (comment: Comment) => {
-    let onOpenContext = () => {};
+    let onOpenContext;
     if (comment.context) {
       onOpenContext = () => {
         this.setState({

--- a/src/main/js/comment/tags.tsx
+++ b/src/main/js/comment/tags.tsx
@@ -63,7 +63,7 @@ const TranslatedTag = withTranslation("plugins")(({ label, title, t, ...restProp
 });
 
 type ClickableTagProps = {
-  onClick: () => void;
+  onClick?: () => void;
 };
 
 export const EmergencyMergeTag = () => <TranslatedTag icon="exclamation-triangle" label="emergencyMerged" color="danger"/>;


### PR DESCRIPTION
## Proposed changes

When a pull request with a comment on it changes, the comment is displayed as outdated. Comments which referred to a line in the source code should have a clickable tag on them to open the original information. Comments which did not refer to a line in code, should not but were incorrectly displayed as such. All that needed to be done is set the default click handler to undefined by default and mark all click handlers as optional. The tag already handled the correct highlighting based on the presence of the click handler.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] PR is well described and the description can be used as commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [ ] New code is covered with unit tests
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)
- [ ] Documentation updated (only necessary for new features or changed behaviour)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
