### PR TITLE
Prevent collapsed diffs from reopen on refocus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Added
 - System replies which are not modifiable nor deletable ([#130](https://github.com/scm-manager/scm-review-plugin/pull/130)
-
 ## Changed
 - Make pull request enrichable by embedded objects ([#130](https://github.com/scm-manager/scm-review-plugin/pull/130)
+### Fixed
+- Prevent collapsed diffs from reopen on page refocus ([#131](https://github.com/scm-manager/scm-review-plugin/pull/131))
 
 ## 2.8.0 - 2021-04-07
 ### Added

--- a/src/main/js/PullRequestInformation.tsx
+++ b/src/main/js/PullRequestInformation.tsx
@@ -103,46 +103,34 @@ class PullRequestInformation extends React.Component<Props> {
       const sourceRevision = isClosedPullRequest && pullRequest?.sourceRevision ? pullRequest.sourceRevision : source;
       const targetRevision = isClosedPullRequest && pullRequest?.targetRevision ? pullRequest.targetRevision : target;
       routeChangeset = (
-        <Route
-          path={`${baseURL}/changesets`}
-          render={() => (
-            <Changesets
-              repository={repository}
-              source={sourceRevision}
-              target={targetRevision}
-              shouldFetchChangesets={shouldFetchChangesets}
-            />
-          )}
-          exact
-        />
+        <Route path={`${baseURL}/changesets`} exact>
+          <Changesets
+            repository={repository}
+            source={sourceRevision}
+            target={targetRevision}
+            shouldFetchChangesets={shouldFetchChangesets}
+          />
+        </Route>
       );
       routeChangesetPagination = (
-        <Route
-          path={`${baseURL}/changesets/:page`}
-          render={() => (
-            <Changesets
-              repository={repository}
-              source={sourceRevision}
-              target={targetRevision}
-              shouldFetchChangesets={shouldFetchChangesets}
-            />
-          )}
-          exact
-        />
+        <Route path={`${baseURL}/changesets/:page`} exact>
+          <Changesets
+            repository={repository}
+            source={sourceRevision}
+            target={targetRevision}
+            shouldFetchChangesets={shouldFetchChangesets}
+          />
+        </Route>
       );
       routeDiff = (
-        <Route
-          path={`${baseURL}/diff`}
-          render={() => (
-            <DiffRoute
-              repository={repository}
-              pullRequest={pullRequest}
-              source={sourceRevision}
-              target={targetRevision}
-            />
-          )}
-          exact
-        />
+        <Route path={`${baseURL}/diff`} exact>
+          <DiffRoute
+            repository={repository}
+            pullRequest={pullRequest}
+            source={sourceRevision}
+            target={targetRevision}
+          />
+        </Route>
       );
       diffTab = (
         <li className={this.navigationClass("diff")}>

--- a/src/main/js/diff/Diff.tsx
+++ b/src/main/js/diff/Diff.tsx
@@ -82,6 +82,10 @@ class Diff extends React.Component<Props, State> {
     };
   }
 
+  shouldComponentUpdate(nextProps: Readonly<Props>, nextState: Readonly<State>) {
+    return this.state.collapsed !== nextState.collapsed;
+  }
+
   render() {
     const { diffUrl, fileContentFactory, diffState, t } = this.props;
     const { collapsed } = this.state;


### PR DESCRIPTION
## Proposed changes

Prevent reset of diff collapsed state on refocus of pull request details page.

### Your checklist for this pull request

- [x] PR is well described and the description can be used as commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`


### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
