### PR TITLE
Feature/pr author as commit author for squash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+- Set pull request author as commit author for squash commits via SCMM ([#134](https://github.com/scm-manager/scm-review-plugin/pull/134))
+
 ## 2.9.0 - 2021-04-22
 ### Added
 - System replies which are not modifiable nor deletable ([#130](https://github.com/scm-manager/scm-review-plugin/pull/130)

--- a/src/main/java/com/cloudogu/scm/review/pullrequest/api/MergeResource.java
+++ b/src/main/java/com/cloudogu/scm/review/pullrequest/api/MergeResource.java
@@ -40,6 +40,7 @@ import sonia.scm.api.v2.resources.ErrorDto;
 import sonia.scm.repository.NamespaceAndName;
 import sonia.scm.repository.api.MergeStrategy;
 import sonia.scm.repository.spi.MergeConflictResult;
+import sonia.scm.user.DisplayUser;
 import sonia.scm.web.VndMediaType;
 
 import javax.inject.Inject;
@@ -55,6 +56,8 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.UriInfo;
 import java.util.List;
+
+import static java.lang.String.format;
 
 @Path(MergeResource.MERGE_PATH_V2)
 public class MergeResource {
@@ -228,7 +231,7 @@ public class MergeResource {
     @PathParam("pullRequestId") String pullRequestId,
     @QueryParam("strategy") MergeStrategy strategy
   ) {
-    return service.createDefaultCommitMessage(new NamespaceAndName(namespace, name), pullRequestId, strategy);
+    return service.createCommitDefaults(new NamespaceAndName(namespace, name), pullRequestId, strategy).getCommitMessage();
   }
 
   @GET
@@ -261,10 +264,13 @@ public class MergeResource {
     @PathParam("pullRequestId") String pullRequestId,
     @QueryParam("strategy") MergeStrategy strategy
   ) {
+    MergeService.CommitDefaults commitDefaults = service.createCommitDefaults(new NamespaceAndName(namespace, name), pullRequestId, strategy);
+    DisplayUser commitAuthor = commitDefaults.getCommitAuthor();
     return new MergeStrategyInfoDto(
       service.isCommitMessageDisabled(strategy),
-      service.createDefaultCommitMessage(new NamespaceAndName(namespace, name), pullRequestId, strategy),
-      service.createMergeCommitMessageHint(strategy)
+      commitDefaults.getCommitMessage(),
+      service.createMergeCommitMessageHint(strategy),
+      format("%s <%s>", commitAuthor.getDisplayName(), commitAuthor.getMail())
     );
   }
 }

--- a/src/main/java/com/cloudogu/scm/review/pullrequest/dto/MergeStrategyInfoDto.java
+++ b/src/main/java/com/cloudogu/scm/review/pullrequest/dto/MergeStrategyInfoDto.java
@@ -40,4 +40,5 @@ public class MergeStrategyInfoDto {
   private String defaultCommitMessage;
   @JsonInclude(JsonInclude.Include.NON_EMPTY)
   private String commitMessageHint;
+  private String commitAuthor;
 }

--- a/src/main/js/MergeForm.tsx
+++ b/src/main/js/MergeForm.tsx
@@ -35,6 +35,7 @@ type Props = WithTranslation & {
   commitMessage: string;
   commitMessageDisabled?: boolean;
   commitMessageHint?: string;
+  commitAuthor?: string;
   onChangeCommitMessage: (message: string) => void;
   onResetCommitMessage: () => void;
   shouldDeleteSourceBranch: boolean;
@@ -74,8 +75,14 @@ class MergeForm extends React.Component<Props> {
       onChangeDeleteSourceBranch,
       onResetCommitMessage,
       commitMessageHint,
+      commitAuthor,
       t
     } = this.props;
+
+    const renderCommitAuthor = (author: string) =>
+      <span className="mb-2">
+        <strong>{t("scm-review-plugin.showPullRequest.mergeModal.commitAuthor")}</strong> {author}
+      </span>;
 
     const commitMessageElement = this.isCommitMessageVisible() && (
       <>
@@ -94,7 +101,7 @@ class MergeForm extends React.Component<Props> {
           </CommitMessageInfo>
         )}
         <MarginBottom>
-          <CommitAuthor />
+          {commitAuthor? renderCommitAuthor(commitAuthor): <CommitAuthor />}
         </MarginBottom>
         <Button label={t("scm-review-plugin.showPullRequest.mergeModal.resetMessage")} action={onResetCommitMessage} />
         <hr />

--- a/src/main/js/MergeModal.tsx
+++ b/src/main/js/MergeModal.tsx
@@ -199,6 +199,7 @@ class MergeModal extends React.Component<Props, State> {
           loading={loadingDefaultMessage}
           commitMessageDisabled={commitStrategyInfos[mergeStrategy]?.commitMessageDisabled}
           commitMessageHint={commitStrategyInfos[mergeStrategy]?.commitMessageHint}
+          commitAuthor={commitStrategyInfos[mergeStrategy]?.commitAuthor}
         />
         {mergeFailed && (
           <>

--- a/src/main/js/types/MergeStrategyInfo.ts
+++ b/src/main/js/types/MergeStrategyInfo.ts
@@ -26,4 +26,5 @@ export interface MergeStrategyInfo {
   commitMessageDisabled: boolean;
   defaultCommitMessage: string;
   commitMessageHint: string;
+  commitAuthor: string;
 }

--- a/src/main/resources/locales/de/plugins.json
+++ b/src/main/resources/locales/de/plugins.json
@@ -99,6 +99,7 @@
           "help": "Nach einem erfolgreichen Merge wird der Source-Branch entfernt"
         },
         "commitMessage": "Bitte Commit Nachricht eingeben",
+        "commitAuthor": "Autor",
         "resetMessage": "Nachricht zurücksetzen",
         "commitMessageHint": {
           "FAST_FORWARD_IF_POSSIBLE": "Diese Nachricht wird nur genutzt, wenn Fast Forward nicht möglich ist."

--- a/src/main/resources/locales/en/plugins.json
+++ b/src/main/resources/locales/en/plugins.json
@@ -99,6 +99,7 @@
           "help": "Source branch will be deleted after successful merge"
         },
         "commitMessage": "Please insert your commit message",
+        "commitAuthor": "Author",
         "resetMessage": "Reset message",
         "commitMessageHint": {
           "FAST_FORWARD_IF_POSSIBLE": "This message will only be used, when fast forward is not possible."


### PR DESCRIPTION
## Proposed changes

Set pull request author as commit author for squash commits via the SCM-Manager UI. Also set the actual committer in the commit message.

### Your checklist for this pull request

- [x] PR is well described and the description can be used as commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [x] New code is covered with unit tests
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)
- [ ] Documentation updated (only necessary for new features or changed behaviour)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
