### PR TITLE
Fix pull request comments not opening/closing unless the window is refocused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Set pull request author as commit author for squash commits via SCMM ([#134](https://github.com/scm-manager/scm-review-plugin/pull/134))
 
+### Fixed
+- Fix pull request comments not opening/closing unless the window is refocused ([#135](https://github.com/scm-manager/scm-review-plugin/pull/135))
+
 ## 2.9.0 - 2021-04-22
 ### Added
 - System replies which are not modifiable nor deletable ([#130](https://github.com/scm-manager/scm-review-plugin/pull/130)

--- a/src/main/js/PullRequestInformation.tsx
+++ b/src/main/js/PullRequestInformation.tsx
@@ -23,7 +23,7 @@
  */
 import React from "react";
 import { Repository } from "@scm-manager/ui-types";
-import { urls, Icon } from "@scm-manager/ui-components";
+import { Icon, urls } from "@scm-manager/ui-components";
 import { WithTranslation, withTranslation } from "react-i18next";
 import Changesets from "./Changesets";
 import { Link, Redirect, Route, RouteComponentProps, Switch, withRouter } from "react-router-dom";
@@ -138,13 +138,9 @@ class PullRequestInformation extends React.Component<Props> {
         </li>
       );
       routeConflicts = !mergeHasNoConflict && (
-        <Route
-          path={`${baseURL}/conflicts`}
-          render={() => (
-            <MergeConflicts repository={repository} pullRequest={pullRequest} source={source} target={target} />
-          )}
-          exact
-        />
+        <Route path={`${baseURL}/conflicts`} exact>
+          <MergeConflicts repository={repository} pullRequest={pullRequest} source={source} target={target} />
+        </Route>
       );
       conflictsTab = !mergeHasNoConflict && (
         <li className={this.navigationClass("conflicts")}>
@@ -158,7 +154,9 @@ class PullRequestInformation extends React.Component<Props> {
     const routes = (
       <Switch>
         <Redirect from={baseURL} to={urls.concat(baseURL, pullRequest ? "comments" : "changesets")} exact />
-        <Route path={`${baseURL}/comments`} render={() => <RootComments pullRequest={pullRequest} />} exact />
+        <Route path={`${baseURL}/comments`} exact>
+          <RootComments pullRequest={pullRequest} />
+        </Route>
         {routeChangeset}
         {routeChangesetPagination}
         {routeDiff}

--- a/src/main/js/SinglePullRequest.tsx
+++ b/src/main/js/SinglePullRequest.tsx
@@ -114,29 +114,22 @@ class SinglePullRequest extends React.Component<Props, State> {
 
     return (
       <Switch>
-        <Route
-          component={() => (
-            <Edit
-              repository={repository}
-              pullRequest={pullRequest}
-              userAutocompleteLink={userAutocompleteLink}
-              fetchPullRequest={this.fetchPullRequest}
-            />
-          )}
-          path={`${match.url}/edit`}
-          exact
-        />
-        <Route
-          component={() => (
-            <PullRequestDetails
-              repository={repository}
-              pullRequest={pullRequest}
-              fetchReviewer={this.fetchReviewer}
-              fetchPullRequest={this.fetchPullRequest}
-            />
-          )}
-          path={`${match.url}`}
-        />
+        <Route path={`${match.url}/edit`} exact>
+          <Edit
+            repository={repository}
+            pullRequest={pullRequest}
+            userAutocompleteLink={userAutocompleteLink}
+            fetchPullRequest={this.fetchPullRequest}
+          />
+        </Route>
+        <Route path={`${match.url}`}>
+          <PullRequestDetails
+            repository={repository}
+            pullRequest={pullRequest}
+            fetchReviewer={this.fetchReviewer}
+            fetchPullRequest={this.fetchPullRequest}
+          />
+        </Route>
       </Switch>
     );
   }

--- a/src/main/js/diff/Diff.tsx
+++ b/src/main/js/diff/Diff.tsx
@@ -83,7 +83,7 @@ class Diff extends React.Component<Props, State> {
   }
 
   shouldComponentUpdate(nextProps: Readonly<Props>, nextState: Readonly<State>) {
-    return this.state.collapsed !== nextState.collapsed;
+    return this.state.collapsed !== nextState.collapsed || this.props.diffState !== nextProps.diffState;
   }
 
   render() {

--- a/src/main/js/index.tsx
+++ b/src/main/js/index.tsx
@@ -49,12 +49,9 @@ const reviewSupportedPredicate = (props: object) => {
 
 const NewPullRequestRoute = props => {
   return (
-    <Route
-      path={`${props.url}/pull-requests/add`}
-      render={() => (
-        <Create repository={props.repository} userAutocompleteLink={getUserAutoCompleteLink(props.indexLinks)} />
-      )}
-    />
+    <Route path={`${props.url}/pull-requests/add`}>
+      <Create repository={props.repository} userAutocompleteLink={getUserAutoCompleteLink(props.indexLinks)} />
+    </Route>
   );
 };
 
@@ -74,15 +71,12 @@ export function getUserAutoCompleteLink(indexLinks) {
 
 const ShowPullRequestRoute = props => {
   return (
-    <Route
-      path={`${props.url}/pull-request/:pullRequestNumber`}
-      render={() => (
-        <SinglePullRequest
-          repository={props.repository}
-          userAutocompleteLink={getUserAutoCompleteLink(props.indexLinks)}
-        />
-      )}
-    />
+    <Route path={`${props.url}/pull-request/:pullRequestNumber`}>
+      <SinglePullRequest
+        repository={props.repository}
+        userAutocompleteLink={getUserAutoCompleteLink(props.indexLinks)}
+      />
+    </Route>
   );
 };
 
@@ -102,7 +96,11 @@ const PullRequestNavLink = ({ url }) => {
 binder.bind("repository.navigation", PullRequestNavLink, reviewSupportedPredicate);
 
 const ShowPullRequestsRoute = ({ url, repository }) => {
-  return <Route path={`${url}/pull-requests/`} render={() => <PullRequestList repository={repository} />} exact />;
+  return (
+    <Route path={`${url}/pull-requests/`} exact>
+      <PullRequestList repository={repository} />
+    </Route>
+  );
 };
 
 binder.bind("repository.route", ShowPullRequestsRoute);
@@ -113,7 +111,12 @@ binder.bind("repos.branch-details.information", ({ repository, branch }) => (
 
 binder.bind("repository.card.quickLink", RepositoryPullRequestCardLink, reviewSupportedPredicate);
 
-cfgBinder.bindRepositorySetting("/review", "scm-review-plugin.navLink.pullRequest", "pullRequestConfig", RepositoryConfig);
+cfgBinder.bindRepositorySetting(
+  "/review",
+  "scm-review-plugin.navLink.pullRequest",
+  "pullRequestConfig",
+  RepositoryConfig
+);
 cfgBinder.bindGlobal("/review", "scm-review-plugin.navLink.pullRequest", "pullRequestConfig", GlobalConfig);
 
 cfgBinder.bindRepositorySetting("/workflow", "scm-review-plugin.navLink.workflow", "workflowConfig", RepoEngineConfig);


### PR DESCRIPTION
## Proposed changes

It is currently not possible to comment on lines in PR diffs unless the active SCM-Manager tab is unfocused and then refocused. This is because the component update is prevented, even if the state-prop changed.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [ ] New code is covered with unit tests
- [ ] New ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [x] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [x] All new code/logic is implemented on the right spot / "Should this be done here?"
- [x] UI changes fits into the layout
- [x] The UI views / components are responsive (mobile views)
- [x] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [x] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [x] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
