### PR TITLE
Do not show update notification if changes already fetched

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Create index for pull requests to make them searchable ([#143](https://github.com/scm-manager/scm-review-plugin/pull/143))
 
+### Fixed
+- Do not show update notification if changes already fetched ([146](https://github.com/scm-manager/scm-review-plugin/pull/146))
+
 ## 2.10.1 - 2021-08-25
-## Fixed
+### Fixed
 - Closing comment editors on parallel changes ([#140](https://github.com/scm-manager/scm-review-plugin/pull/140))
 - Missing merge button update after approval and comment action ([#141](https://github.com/scm-manager/scm-review-plugin/pull/141))
 - Too wide branch selection when creating pr ([#142](https://github.com/scm-manager/scm-review-plugin/pull/142))
 
 ## 2.10.0 - 2021-08-04
-## Changed
+### Changed
 - Use react-query to enable frontend caching ([#138](https://github.com/scm-manager/scm-review-plugin/pull/138))
 
 ## 2.9.2 - 2021-07-06

--- a/src/main/js/ChangeNotificationContext.tsx
+++ b/src/main/js/ChangeNotificationContext.tsx
@@ -1,0 +1,59 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import React, { FC, useContext } from "react";
+
+type Callback = () => void;
+
+type SubscriptionContextType = {
+  onReload: (callback: Callback) => () => void;
+  reload: () => void;
+};
+
+const createSubscriptionContext = (): SubscriptionContextType => {
+  const listeners: Callback[] = [];
+  return {
+    onReload: (callback: Callback) => {
+      const idx = listeners.push(callback);
+      return () => listeners.splice(idx, 1);
+    },
+    reload: () => {
+      listeners.forEach(c => c());
+    }
+  };
+};
+
+const defaultSubscriptionContext = createSubscriptionContext();
+
+const Context = React.createContext(defaultSubscriptionContext);
+
+const ChangeNotificationContext: FC = ({ children }) => (
+  <Context.Provider value={defaultSubscriptionContext}>{children}</Context.Provider>
+);
+
+export const useChangeNotificationContext = () => {
+  return useContext(Context);
+};
+
+export default ChangeNotificationContext;

--- a/src/main/js/ChangeNotificationToast.tsx
+++ b/src/main/js/ChangeNotificationToast.tsx
@@ -1,0 +1,53 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import React, { FC } from "react";
+import { Toast, ToastButton, ToastButtons } from "@scm-manager/ui-components";
+import { useTranslation } from "react-i18next";
+
+type Props = {
+  reload: () => void;
+  ignore: () => void;
+};
+
+const ChangeNotificationToast: FC<Props> = ({ reload, ignore }) => {
+  const { t } = useTranslation("plugins");
+
+  return (
+    <Toast type="warning" title={t("scm-review-plugin.changeNotification.title")}>
+      <p>{t("scm-review-plugin.changeNotification.description")}</p>
+      <p>{t("scm-review-plugin.changeNotification.modificationWarning")}</p>
+      <ToastButtons>
+        <ToastButton icon="redo" onClick={reload}>
+          {t("scm-review-plugin.changeNotification.buttons.reload")}
+        </ToastButton>
+        <ToastButton icon="times" onClick={ignore}>
+          {t("scm-review-plugin.changeNotification.buttons.ignore")}
+        </ToastButton>
+      </ToastButtons>
+    </Toast>
+  );
+};
+
+export default ChangeNotificationToast;

--- a/src/main/js/PullRequestDetails.tsx
+++ b/src/main/js/PullRequestDetails.tsx
@@ -53,6 +53,7 @@ import PullRequestTitle from "./PullRequestTitle";
 import Statusbar from "./workflow/Statusbar";
 import BranchTag from "./BranchTag";
 import PullRequestStatusTag from "./PullRequestStatusTag";
+import ChangeNotificationContext from "./ChangeNotificationContext";
 
 type Props = {
   repository: Repository;
@@ -281,7 +282,7 @@ const PullRequestDetails: FC<Props> = ({ repository, pullRequest }) => {
   };
 
   return (
-    <>
+    <ChangeNotificationContext>
       <ChangeNotification repository={repository} pullRequest={pullRequest} />
       <Container>
         <div className="media">
@@ -385,7 +386,7 @@ const PullRequestDetails: FC<Props> = ({ repository, pullRequest }) => {
         mergeHasNoConflict={!mergeCheck?.hasConflicts}
         targetBranchDeleted={targetBranchDeleted}
       />
-    </>
+    </ChangeNotificationContext>
   );
 };
 


### PR DESCRIPTION
## Proposed changes

Notifications are only shown if the tab is focused. 
This avoids to many connection problems with sse and notifications for already loaded content.
If the tab is focused and diff is selected, we check if the source or target branch has changed to show a notification.

### Your checklist for this pull request

**Contributor**:
- [X] PR is well described and the description can be used as a commit message on squash
- [X] Related issues linked to PR if existing and labels set
- [X] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
