### PR TITLE
Fix error when user without mail merges

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ dependencies {
 }
 
 scmPlugin {
-  scmVersion = "2.23.0"
+  scmVersion = "2.23.1-SNAPSHOT"
   displayName = "Review"
   description = "Depict a review process with pull requests"
   author = "Cloudogu GmbH"

--- a/src/main/java/com/cloudogu/scm/review/pullrequest/api/MergeResource.java
+++ b/src/main/java/com/cloudogu/scm/review/pullrequest/api/MergeResource.java
@@ -38,9 +38,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import sonia.scm.api.v2.resources.ErrorDto;
 import sonia.scm.repository.NamespaceAndName;
+import sonia.scm.repository.Person;
 import sonia.scm.repository.api.MergeStrategy;
 import sonia.scm.repository.spi.MergeConflictResult;
-import sonia.scm.user.DisplayUser;
 import sonia.scm.web.VndMediaType;
 
 import javax.inject.Inject;
@@ -265,12 +265,12 @@ public class MergeResource {
     @QueryParam("strategy") MergeStrategy strategy
   ) {
     MergeService.CommitDefaults commitDefaults = service.createCommitDefaults(new NamespaceAndName(namespace, name), pullRequestId, strategy);
-    DisplayUser commitAuthor = commitDefaults.getCommitAuthor();
+    Person commitAuthor = commitDefaults.getCommitAuthor();
     return new MergeStrategyInfoDto(
       service.isCommitMessageDisabled(strategy),
       commitDefaults.getCommitMessage(),
       service.createMergeCommitMessageHint(strategy),
-      format("%s <%s>", commitAuthor.getDisplayName(), commitAuthor.getMail())
+      format("%s <%s>", commitAuthor.getName(), commitAuthor.getMail())
     );
   }
 }

--- a/src/test/java/com/cloudogu/scm/review/pullrequest/api/MergeResourceTest.java
+++ b/src/test/java/com/cloudogu/scm/review/pullrequest/api/MergeResourceTest.java
@@ -36,8 +36,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import sonia.scm.repository.NamespaceAndName;
-import sonia.scm.user.DisplayUser;
-import sonia.scm.user.User;
+import sonia.scm.repository.Person;
 import sonia.scm.web.RestDispatcher;
 
 import java.io.IOException;
@@ -52,7 +51,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static sonia.scm.repository.api.MergeStrategy.FAST_FORWARD_IF_POSSIBLE;
@@ -136,7 +134,7 @@ class MergeResourceTest {
   @Test
   void shouldCreateSquashCommitMessage() throws IOException, URISyntaxException {
     when(mergeService.createCommitDefaults(any(), any(), eq(SQUASH)))
-      .thenReturn(new CommitDefaults("successful", DisplayUser.from(new User("Arthur Dent"))));
+      .thenReturn(new CommitDefaults("successful", new Person("Arthur Dent")));
     MockHttpRequest request = createHttpGetRequest(MERGE_URL + "/commit-message/?strategy=SQUASH");
     MockHttpResponse response = new MockHttpResponse();
     dispatcher.invoke(request, response);
@@ -147,7 +145,7 @@ class MergeResourceTest {
   @Test
   void shouldGetSquashMergeStrategyInfo() throws URISyntaxException, UnsupportedEncodingException {
     when(mergeService.createCommitDefaults(any(), any(), eq(SQUASH)))
-      .thenReturn(new CommitDefaults("happy days", DisplayUser.from(new User("Arthur Dent"))));
+      .thenReturn(new CommitDefaults("happy days", new Person("Arthur Dent")));
     when(mergeService.isCommitMessageDisabled(SQUASH)).thenReturn(true);
     when(mergeService.createMergeCommitMessageHint(SQUASH)).thenReturn(null);
     MockHttpRequest request = createHttpGetRequest(MERGE_URL + "/merge-strategy-info/?strategy=SQUASH");
@@ -163,7 +161,7 @@ class MergeResourceTest {
 
   @Test
   void shouldGetRebaseMergeStrategyInfo() throws URISyntaxException, UnsupportedEncodingException {
-    CommitDefaults commitDefaults = new CommitDefaults("happy days", DisplayUser.from(new User("Arthur Dent")));
+    CommitDefaults commitDefaults = new CommitDefaults("happy days", new Person("Arthur Dent"));
     when(mergeService.createCommitDefaults(any(), any(), eq(REBASE))).thenReturn(commitDefaults);
     when(mergeService.isCommitMessageDisabled(REBASE)).thenReturn(true);
     when(mergeService.createMergeCommitMessageHint(REBASE)).thenReturn(null);


### PR DESCRIPTION
## Proposed changes

This fixes an error, when a user without configured email
address tries to merge a pull request.

To do so, we use the EMail class from the core to determine
a mail address for a user and is used in the modify command
already to compute mail addresses for users without one.
Sadly though, we have to switch from DisplayUser to Person,
because we cannot "correct" the mail addess in a DisplayUser
instance.

This requires scm-manager/scm-manager#1815

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [x] New code is covered with unit tests
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
