### PR TITLE
Fix merge by user without mail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- Merges by users without configured mail address
+
 ## 2.11.0 - 2021-09-08
 ### Added
 - Create index for pull requests to make them searchable ([#143](https://github.com/scm-manager/scm-review-plugin/pull/143))

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ dependencies {
 }
 
 scmPlugin {
-  scmVersion = "2.23.0"
+  scmVersion = "2.23.1-SNAPSHOT"
   displayName = "Review"
   description = "Depict a review process with pull requests"
   author = "Cloudogu GmbH"

--- a/src/main/java/com/cloudogu/scm/review/pullrequest/api/MergeResource.java
+++ b/src/main/java/com/cloudogu/scm/review/pullrequest/api/MergeResource.java
@@ -36,6 +36,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import org.apache.commons.lang.StringUtils;
 import sonia.scm.api.v2.resources.ErrorDto;
 import sonia.scm.repository.NamespaceAndName;
 import sonia.scm.repository.api.MergeStrategy;
@@ -278,6 +279,6 @@ public class MergeResource {
     if (commitAuthor == null) {
       return null;
     }
-    return commitAuthor.getMail() == null ? commitAuthor.getDisplayName() : format("%s <%s>", commitAuthor.getDisplayName(), commitAuthor.getMail());
+    return StringUtils.isEmpty(commitAuthor.getMail()) ? commitAuthor.getDisplayName() : format("%s <%s>", commitAuthor.getDisplayName(), commitAuthor.getMail());
   }
 }

--- a/src/main/java/com/cloudogu/scm/review/pullrequest/api/MergeResource.java
+++ b/src/main/java/com/cloudogu/scm/review/pullrequest/api/MergeResource.java
@@ -270,7 +270,14 @@ public class MergeResource {
       service.isCommitMessageDisabled(strategy),
       commitDefaults.getCommitMessage(),
       service.createMergeCommitMessageHint(strategy),
-      format("%s <%s>", commitAuthor.getDisplayName(), commitAuthor.getMail())
+      renderCommitAuthorIfPresent(commitAuthor)
     );
+  }
+
+  private String renderCommitAuthorIfPresent(DisplayUser commitAuthor) {
+    if (commitAuthor == null) {
+      return null;
+    }
+    return commitAuthor.getMail() == null ? commitAuthor.getDisplayName() : format("%s <%s>", commitAuthor.getDisplayName(), commitAuthor.getMail());
   }
 }

--- a/src/main/java/com/cloudogu/scm/review/pullrequest/dto/MergeStrategyInfoDto.java
+++ b/src/main/java/com/cloudogu/scm/review/pullrequest/dto/MergeStrategyInfoDto.java
@@ -40,5 +40,6 @@ public class MergeStrategyInfoDto {
   private String defaultCommitMessage;
   @JsonInclude(JsonInclude.Include.NON_EMPTY)
   private String commitMessageHint;
+  @JsonInclude(JsonInclude.Include.NON_EMPTY)
   private String commitAuthor;
 }

--- a/src/main/java/com/cloudogu/scm/review/pullrequest/service/MergeService.java
+++ b/src/main/java/com/cloudogu/scm/review/pullrequest/service/MergeService.java
@@ -203,7 +203,7 @@ public class MergeService {
   public CommitDefaults createCommitDefaults(NamespaceAndName namespaceAndName, String pullRequestId, MergeStrategy strategy) {
     PullRequest pullRequest = pullRequestService.get(namespaceAndName.getNamespace(), namespaceAndName.getName(), pullRequestId);
     String message = determineDefaultMessage(namespaceAndName, pullRequest, strategy);
-    DisplayUser author = determineDefaultAuthor(pullRequest, strategy);
+    DisplayUser author = determineDefaultAuthorIfNotCurrentUser(pullRequest, strategy);
     return new CommitDefaults(message, author);
   }
 
@@ -221,9 +221,9 @@ public class MergeService {
     }
   }
 
-  public DisplayUser determineDefaultAuthor(PullRequest pullRequest, MergeStrategy strategy) {
+  public DisplayUser determineDefaultAuthorIfNotCurrentUser(PullRequest pullRequest, MergeStrategy strategy) {
     if (strategy == null) {
-      return currentDisplayUser();
+      return null;
     }
     switch (strategy) {
       case SQUASH:
@@ -231,7 +231,7 @@ public class MergeService {
       case FAST_FORWARD_IF_POSSIBLE:
       case MERGE_COMMIT:
       default:
-        return currentDisplayUser();
+        return null;
     }
   }
 
@@ -342,8 +342,8 @@ public class MergeService {
     mergeCommand.setTargetBranch(pullRequest.getTarget());
     String enrichedCommitMessage = enrichCommitMessageWithTrailers(repositoryService, pullRequest, mergeCommitDto, strategy);
     mergeCommand.setMessage(enrichedCommitMessage);
-    DisplayUser author = determineDefaultAuthor(pullRequest, strategy);
-    mergeCommand.setAuthor(new Person(author.getDisplayName(), author.getMail()));
+    DisplayUser author = determineDefaultAuthorIfNotCurrentUser(pullRequest, strategy);
+    mergeCommand.setAuthor(author);
     mergeCommand.setMergeStrategy(strategy);
   }
 

--- a/src/main/js/types/MergeStrategyInfo.ts
+++ b/src/main/js/types/MergeStrategyInfo.ts
@@ -26,5 +26,5 @@ export interface MergeStrategyInfo {
   commitMessageDisabled: boolean;
   defaultCommitMessage: string;
   commitMessageHint: string;
-  commitAuthor: string | null;
+  commitAuthor?: string;
 }

--- a/src/main/js/types/MergeStrategyInfo.ts
+++ b/src/main/js/types/MergeStrategyInfo.ts
@@ -26,5 +26,5 @@ export interface MergeStrategyInfo {
   commitMessageDisabled: boolean;
   defaultCommitMessage: string;
   commitMessageHint: string;
-  commitAuthor: string;
+  commitAuthor: string | null;
 }

--- a/src/test/java/com/cloudogu/scm/review/pullrequest/api/MergeResourceTest.java
+++ b/src/test/java/com/cloudogu/scm/review/pullrequest/api/MergeResourceTest.java
@@ -182,7 +182,7 @@ class MergeResourceTest {
     JsonMockHttpResponse response = new JsonMockHttpResponse();
     dispatcher.invoke(request, response);
     JsonNode jsonResponse = response.getContentAsJson();
-    assertThat(jsonResponse.get("commitAuthor").isNull()).isTrue();
+    assertThat(jsonResponse.get("commitAuthor")).isNull();
   }
 
   @Test

--- a/src/test/java/com/cloudogu/scm/review/pullrequest/api/MergeResourceTest.java
+++ b/src/test/java/com/cloudogu/scm/review/pullrequest/api/MergeResourceTest.java
@@ -26,6 +26,7 @@ package com.cloudogu.scm.review.pullrequest.api;
 import com.cloudogu.scm.review.pullrequest.service.MergeCheckResult;
 import com.cloudogu.scm.review.pullrequest.service.MergeService;
 import com.cloudogu.scm.review.pullrequest.service.MergeService.CommitDefaults;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.github.sdorra.shiro.SubjectAware;
 import org.jboss.resteasy.mock.MockHttpRequest;
 import org.jboss.resteasy.mock.MockHttpResponse;
@@ -38,6 +39,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import sonia.scm.repository.NamespaceAndName;
 import sonia.scm.user.DisplayUser;
 import sonia.scm.user.User;
+import sonia.scm.web.JsonMockHttpResponse;
 import sonia.scm.web.RestDispatcher;
 
 import java.io.IOException;
@@ -52,10 +54,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static sonia.scm.repository.api.MergeStrategy.FAST_FORWARD_IF_POSSIBLE;
+import static sonia.scm.repository.api.MergeStrategy.MERGE_COMMIT;
 import static sonia.scm.repository.api.MergeStrategy.REBASE;
 import static sonia.scm.repository.api.MergeStrategy.SQUASH;
 
@@ -145,20 +147,42 @@ class MergeResourceTest {
   }
 
   @Test
-  void shouldGetSquashMergeStrategyInfo() throws URISyntaxException, UnsupportedEncodingException {
+  void shouldGetSquashMergeStrategyInfoWithoutMail() throws URISyntaxException {
     when(mergeService.createCommitDefaults(any(), any(), eq(SQUASH)))
       .thenReturn(new CommitDefaults("happy days", DisplayUser.from(new User("Arthur Dent"))));
     when(mergeService.isCommitMessageDisabled(SQUASH)).thenReturn(true);
     when(mergeService.createMergeCommitMessageHint(SQUASH)).thenReturn(null);
     MockHttpRequest request = createHttpGetRequest(MERGE_URL + "/merge-strategy-info/?strategy=SQUASH");
-    MockHttpResponse response = new MockHttpResponse();
+    JsonMockHttpResponse response = new JsonMockHttpResponse();
     dispatcher.invoke(request, response);
     assertThat(response.getStatus()).isEqualTo(200);
-    assertThat(response.getContentAsString())
-      .contains("happy days")
-      .contains("true")
-      .contains("Arthur Dent")
-      .doesNotContain("commitMessageHint");
+    JsonNode jsonResponse = response.getContentAsJson();
+    assertThat(jsonResponse.get("commitMessageDisabled").asBoolean()).isTrue();
+    assertThat(jsonResponse.get("defaultCommitMessage").asText()).isEqualTo("happy days");
+    assertThat(jsonResponse.get("commitAuthor").asText()).isEqualTo("Arthur Dent");
+    assertThat(jsonResponse.get("commitMessageHint")).isNull();
+  }
+
+  @Test
+  void shouldGetSquashMergeStrategyInfoWithMail() throws URISyntaxException {
+    when(mergeService.createCommitDefaults(any(), any(), eq(SQUASH)))
+      .thenReturn(new CommitDefaults("happy days", DisplayUser.from(new User("dent", "Arthur Dent", "arthur@hitchhiker.com"))));
+    MockHttpRequest request = createHttpGetRequest(MERGE_URL + "/merge-strategy-info/?strategy=SQUASH");
+    JsonMockHttpResponse response = new JsonMockHttpResponse();
+    dispatcher.invoke(request, response);
+    JsonNode jsonResponse = response.getContentAsJson();
+    assertThat(jsonResponse.get("commitAuthor").asText()).isEqualTo("Arthur Dent <arthur@hitchhiker.com>");
+  }
+
+  @Test
+  void shouldNotSetCommitAuthorForNonSquash() throws URISyntaxException {
+    when(mergeService.createCommitDefaults(any(), any(), eq(MERGE_COMMIT)))
+      .thenReturn(new CommitDefaults("happy days", null));
+    MockHttpRequest request = createHttpGetRequest(MERGE_URL + "/merge-strategy-info/?strategy=MERGE_COMMIT");
+    JsonMockHttpResponse response = new JsonMockHttpResponse();
+    dispatcher.invoke(request, response);
+    JsonNode jsonResponse = response.getContentAsJson();
+    assertThat(jsonResponse.get("commitAuthor").isNull()).isTrue();
   }
 
   @Test

--- a/src/test/java/com/cloudogu/scm/review/pullrequest/service/MergeServiceTest.java
+++ b/src/test/java/com/cloudogu/scm/review/pullrequest/service/MergeServiceTest.java
@@ -153,7 +153,6 @@ class MergeServiceTest {
 
   @Test
   void shouldMergeSuccessfully() {
-    mockUser("arthur", "Arthur Dent", "dent@hitchhiker.org");
     when(mergeCommandBuilder.isSupported(MergeStrategy.MERGE_COMMIT)).thenReturn(true);
     when(mergeCommandBuilder.executeMerge()).thenReturn(MergeCommandResult.success("1", "2", "123"));
     mockPullRequest("squash", "master", "1");
@@ -283,7 +282,6 @@ class MergeServiceTest {
 
   @Test
   void shouldEmergencyMergeSuccessfully() {
-    mockUser("arthur", "Arthur Dent", "dent@hitchhiker.org");
     when(mergeCommandBuilder.isSupported(MergeStrategy.MERGE_COMMIT)).thenReturn(true);
     when(mergeCommandBuilder.executeMerge()).thenReturn(MergeCommandResult.success("1", "2", "123"));
     mockPullRequest("squash", "master", "1");
@@ -331,7 +329,6 @@ class MergeServiceTest {
 
   @Test
   void shouldDeleteBranchIfFlagIsSet() {
-    mockUser("arthur", "Arthur Dent", "dent@hitchhiker.org");
     when(mergeCommandBuilder.isSupported(MergeStrategy.MERGE_COMMIT)).thenReturn(true);
     when(mergeCommandBuilder.executeMerge()).thenReturn(MergeCommandResult.success("1", "2", "123"));
     mockPullRequest("squash", "master", "1");
@@ -346,7 +343,6 @@ class MergeServiceTest {
 
   @Test
   void shouldUpdatePullRequestStatus() throws IOException {
-    mockUser("arthur", "Arthur Dent", "dent@hitchhiker.org");
     mocksForPullRequestUpdate("master");
     mockPullRequest("squash", "master", "1");
 
@@ -383,7 +379,6 @@ class MergeServiceTest {
 
   @Test
   void shouldNotThrowExceptionIfObstacleIsOverrideable() throws IOException {
-    mockUser("arthur", "Arthur Dent", "dent@hitchhiker.org");
     mocksForPullRequestUpdate("master");
     PullRequest pullRequest = mockPullRequest("squash", "master", "1");
     mockMergeGuard(pullRequest, true);
@@ -470,6 +465,16 @@ class MergeServiceTest {
   }
 
   @Test
+  void shouldOmitAuthorForNonSquash() {
+    PullRequest pullRequest = createPullRequest();
+    when(pullRequestService.get(REPOSITORY.getNamespace(), REPOSITORY.getName(), "1")).thenReturn(pullRequest);
+
+    CommitDefaults commitDefaults = service.createCommitDefaults(REPOSITORY.getNamespaceAndName(), "1", MergeStrategy.MERGE_COMMIT);
+
+    assertThat(commitDefaults.getCommitAuthor()).isNull();
+  }
+
+  @Test
   void shouldCreateCommitMessageForSquashWithFallbackForMissingAuthorFromPullRequest() throws IOException {
     User user = mockUser("trillian", "Tricia McMillan", "tricia@hitchhiker.com");
     when(subject.isPermitted("repository:read:" + REPOSITORY.getId())).thenReturn(true);
@@ -539,7 +544,6 @@ class MergeServiceTest {
   void shouldClosePullRequestsWithDeletedBranchesOnMerge() {
     PullRequest pullRequest = mockPullRequest("commit", "master", "1");
     PullRequest pullRequest2 = mockPullRequest("master", "commit", "2");
-    mockUser("arthur", "Arthur Dent", "dent@hitchhiker.org");
     when(mergeCommandBuilder.isSupported(MergeStrategy.MERGE_COMMIT)).thenReturn(true);
     when(mergeCommandBuilder.executeMerge()).thenReturn(MergeCommandResult.success("1", "2", "123"));
     when(repositoryService.isSupported(Command.BRANCH)).thenReturn(true);


### PR DESCRIPTION
## Proposed changes

Fix error that occures, when a user without an email address merges a pull request.
    
To do so, we make use of the fallback email mechanisms
from the core. Therefore, we
- do not try to build the author ourselves, if it is the
  current user, and
- use a new method to set the author as DisplayUser to
  make use of fallbacks in the merge command.

This requires scm-manager/scm-manager#1815

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [x] New code is covered with unit tests
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins
- [x] Feature has been tested with different permissions

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
