### PR TITLE
Correct matching of pull-request navigation entry

### DIFF
--- a/src/main/js/index.tsx
+++ b/src/main/js/index.tsx
@@ -91,8 +91,9 @@ binder.bind("repository.route", ShowPullRequestRoute);
 // list
 
 function matches(route: any) {
-  const regex = new RegExp(".*(/pull-request)/.*");
-  return route.location.pathname.match(regex) || route.location.pathname.match(".*(pull-requests)/.*");
+  const singleRegex = new RegExp(".*(/repo)/.+/.+(/pull-request)/.*");
+  const listRegex = new RegExp(".*(/repo)/.+/.+(/pull-requests)/.*");
+  return route.location.pathname.match(singleRegex) || route.location.pathname.match(listRegex);
 }
 
 const PullRequestNavLink = ({ url }) => {


### PR DESCRIPTION
## Proposed changes

Whenever a repository or namespace is called "pull-request" or "pull-requests", the pull requests entry is shown active in the navigation.

### Your checklist for this pull request

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [ ] New code is covered with unit tests
- [ ] New ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
