### PR TITLE
Remove PR Push Message on single Branch repo (#112)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Merges by users without configured mail address ([#149](https://github.com/scm-manager/scm-review-plugin/pull/149))
 - Correct matching of pull-request navigation entry ([#150](https://github.com/scm-manager/scm-review-plugin/pull/150))
+- Remove the Pull Request Link from the push message on a single branch repository ([#112](https://github.com/scm-manager/scm-review-plugin/issues/112))
 
 ## 2.11.0 - 2021-09-08
 ### Added


### PR DESCRIPTION
## Proposed changes

This change introduces a check if the repository in which a push happens has mutliple branches or not.
If it doesn't have more than one branch the push message to create a pull request is suppressed.

fixes #112

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [x] New code is covered with unit tests
- [ ] New ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
