### PR TITLE
Fix pagination with status filters

### DIFF
--- a/gradle/changelog/pagination_filter.yaml
+++ b/gradle/changelog/pagination_filter.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Pagination with status filters ([#193](https://github.com/scm-manager/scm-review-plugin/pull/193))


### PR DESCRIPTION
## Proposed changes

Fix pagination with status filter. The status filter is now being controlled by the query param to ensure the state is still the same after the page was reloaded.

Before the status had been resetted on page change and the page number did stay the same after changing the filter, probably leading to an error if the page does not exist for the new filter.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [ ] Related issues linked to PR if existing and labels set
- [ ] New code is covered with unit tests
- [ ] New/updated ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [x] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [x] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [x] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [x] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
