### PR TITLE
Remove duplicate Buttongroup since it is already set in core

### DIFF
--- a/gradle/changelog/vertical_alignment.yaml
+++ b/gradle/changelog/vertical_alignment.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Remove duplicate Buttongroup since it is already set in core ([#200](https://github.com/scm-manager/scm-review-plugin/pull/200))

--- a/src/main/js/diff/Diff.tsx
+++ b/src/main/js/diff/Diff.tsx
@@ -28,7 +28,6 @@ import { useBranch } from "@scm-manager/ui-api";
 import { Hunk, Repository } from "@scm-manager/ui-types";
 import {
   AnnotationFactoryContext,
-  ButtonGroup,
   DiffEventContext,
   diffs,
   File,
@@ -273,7 +272,7 @@ const Diff: FC<Props> = ({
         setOpenEditors(prevState => ({ ...prevState, [path]: [] }));
       };
       return (
-        <ButtonGroup>
+        <>
           <MarkReviewedButton
             repository={repository}
             pullRequest={pullRequest}
@@ -284,10 +283,10 @@ const Diff: FC<Props> = ({
           />
           <AddCommentButton action={openFileEditor} />
           {contentFactory(file)}
-        </ButtonGroup>
+        </>
       );
     } else {
-      return <ButtonGroup>{contentFactory(file)}</ButtonGroup>;
+      return <>{contentFactory(file)}</>;
     }
   };
 


### PR DESCRIPTION
## Proposed changes

Remove duplicate Buttongroup since it is already set in core.

### Your checklist for this pull request

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [ ] New code is covered with unit tests
- [ ] New/updated ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
