### PR TITLE
Remove card-table action area

### DIFF
--- a/gradle/changelog/remove_table_action.yaml
+++ b/gradle/changelog/remove_table_action.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Remove card-table action area ([#201](https://github.com/scm-manager/scm-review-plugin/pull/201))

--- a/src/main/js/config/BranchList.tsx
+++ b/src/main/js/config/BranchList.tsx
@@ -23,7 +23,7 @@
  */
 import React from "react";
 import { WithTranslation, withTranslation } from "react-i18next";
-import { AddButton, Icon, InputField, Level, Notification } from "@scm-manager/ui-components";
+import { AddButton, Button, InputField, Level, Notification } from "@scm-manager/ui-components";
 import styled from "styled-components";
 
 type Props = WithTranslation & {
@@ -35,8 +35,12 @@ type State = {
   newBranch: string;
 };
 
-const WidthTd = styled.td`
-  width: 7.5rem;
+const VCenteredTd = styled.td`
+  vertical-align: middle !important;
+`;
+
+const WidthVCenteredTd = styled(VCenteredTd)`
+  width: 5rem;
 `;
 
 const FullWidthInputField = styled(InputField)`
@@ -80,16 +84,16 @@ class BranchList extends React.Component<Props, State> {
           <tbody>
             {branches.map(branch => (
               <tr>
-                <td>{branch}</td>
-                <WidthTd className="has-text-centered">
-                  <span
-                    className="icon is-small is-clickable"
-                    onClick={() => this.deleteBranch(branch)}
+                <VCenteredTd>{branch}</VCenteredTd>
+                <WidthVCenteredTd className="has-text-centered">
+                  <Button
+                    color="text"
+                    icon="trash"
+                    action={() => this.deleteBranch(branch)}
                     title={t("scm-review-plugin.config.branchProtection.branches.deleteBranch")}
-                  >
-                    <Icon name="trash" className="has-hover-secondary-invert p-1" />
-                  </span>
-                </WidthTd>
+                    className="px-2"
+                  />
+                </WidthVCenteredTd>
               </tr>
             ))}
           </tbody>

--- a/src/main/js/config/BranchList.tsx
+++ b/src/main/js/config/BranchList.tsx
@@ -35,6 +35,10 @@ type State = {
   newBranch: string;
 };
 
+const WidthTd = styled.td`
+  width: 7.5rem;
+`;
+
 const FullWidthInputField = styled(InputField)`
   width: 100%;
   margin-right: 1.5rem;
@@ -77,7 +81,7 @@ class BranchList extends React.Component<Props, State> {
             {branches.map(branch => (
               <tr>
                 <td>{branch}</td>
-                <td className="has-text-centered">
+                <WidthTd className="has-text-centered">
                   <span
                     className="icon is-small is-clickable"
                     onClick={() => this.deleteBranch(branch)}
@@ -85,7 +89,7 @@ class BranchList extends React.Component<Props, State> {
                   >
                     <Icon name="trash" className="has-hover-secondary-invert p-1" />
                   </span>
-                </td>
+                </WidthTd>
               </tr>
             ))}
           </tbody>

--- a/src/main/js/config/BranchList.tsx
+++ b/src/main/js/config/BranchList.tsx
@@ -35,11 +35,6 @@ type State = {
   newBranch: string;
 };
 
-const VCenteredTd = styled.td`
-  display: table-cell;
-  vertical-align: middle !important;
-`;
-
 const FullWidthInputField = styled(InputField)`
   width: 100%;
   margin-right: 1.5rem;
@@ -82,17 +77,15 @@ class BranchList extends React.Component<Props, State> {
             {branches.map(branch => (
               <tr>
                 <td>{branch}</td>
-                <VCenteredTd className="is-darker">
-                  <a
-                    className="level-item"
+                <td className="has-text-centered">
+                  <span
+                    className="icon is-small is-clickable"
                     onClick={() => this.deleteBranch(branch)}
                     title={t("scm-review-plugin.config.branchProtection.branches.deleteBranch")}
                   >
-                    <span className="icon is-small">
-                      <Icon name="trash" color="inherit" />
-                    </span>
-                  </a>
-                </VCenteredTd>
+                    <Icon name="trash" className="has-hover-secondary-invert p-1" />
+                  </span>
+                </td>
               </tr>
             ))}
           </tbody>

--- a/src/main/js/config/BypassList.tsx
+++ b/src/main/js/config/BypassList.tsx
@@ -30,11 +30,6 @@ import { Link, SelectValue } from "@scm-manager/ui-types";
 import { useIndexLinks } from "@scm-manager/ui-api";
 import styled from "styled-components";
 
-const VCenteredTd = styled.td`
-  display: table-cell;
-  vertical-align: middle !important;
-`;
-
 const useAutoCompleteLinks = () => {
   const links = useIndexLinks()?.autocomplete as Link[];
   return {
@@ -128,17 +123,15 @@ const BypassList: FC<{
               <td>
                 <PermissionIcon bypass={bypass} /> {bypass.name}
               </td>
-              <VCenteredTd className="is-darker">
-                <a
-                  className="level-item"
+              <td className="has-text-centered">
+                <span
+                  className="icon is-small is-clickable"
                   onClick={() => deleteBypass(bypass)}
                   title={t("scm-review-plugin.config.branchProtection.bypasses.deleteBypass")}
                 >
-                  <span className="icon is-small">
-                    <Icon name="trash" color="inherit" />
-                  </span>
-                </a>
-              </VCenteredTd>
+                  <Icon name="trash" className="has-hover-secondary-invert p-1" />
+                </span>
+              </td>
             </tr>
           ))}
         </tbody>

--- a/src/main/js/config/BypassList.tsx
+++ b/src/main/js/config/BypassList.tsx
@@ -30,8 +30,12 @@ import { Link, SelectValue } from "@scm-manager/ui-types";
 import { useIndexLinks } from "@scm-manager/ui-api";
 import styled from "styled-components";
 
-const WidthTd = styled.td`
-  width: 7.5rem;
+const VCenteredTd = styled.td`
+  vertical-align: middle !important;
+`;
+
+const WidthVCenteredTd = styled(VCenteredTd)`
+  width: 5rem;
 `;
 
 const useAutoCompleteLinks = () => {
@@ -124,18 +128,18 @@ const BypassList: FC<{
         <tbody>
           {bypasses.map(bypass => (
             <tr>
-              <td>
+              <VCenteredTd>
                 <PermissionIcon bypass={bypass} /> {bypass.name}
-              </td>
-              <WidthTd className="has-text-centered">
-                <span
-                  className="icon is-small is-clickable"
-                  onClick={() => deleteBypass(bypass)}
+              </VCenteredTd>
+              <WidthVCenteredTd className="has-text-centered">
+                <Button
+                  color="text"
+                  icon="trash"
+                  action={() => deleteBypass(bypass)}
                   title={t("scm-review-plugin.config.branchProtection.bypasses.deleteBypass")}
-                >
-                  <Icon name="trash" className="has-hover-secondary-invert p-1" />
-                </span>
-              </WidthTd>
+                  className="px-2"
+                />
+              </WidthVCenteredTd>
             </tr>
           ))}
         </tbody>

--- a/src/main/js/config/BypassList.tsx
+++ b/src/main/js/config/BypassList.tsx
@@ -30,6 +30,10 @@ import { Link, SelectValue } from "@scm-manager/ui-types";
 import { useIndexLinks } from "@scm-manager/ui-api";
 import styled from "styled-components";
 
+const WidthTd = styled.td`
+  width: 7.5rem;
+`;
+
 const useAutoCompleteLinks = () => {
   const links = useIndexLinks()?.autocomplete as Link[];
   return {
@@ -123,7 +127,7 @@ const BypassList: FC<{
               <td>
                 <PermissionIcon bypass={bypass} /> {bypass.name}
               </td>
-              <td className="has-text-centered">
+              <WidthTd className="has-text-centered">
                 <span
                   className="icon is-small is-clickable"
                   onClick={() => deleteBypass(bypass)}
@@ -131,7 +135,7 @@ const BypassList: FC<{
                 >
                   <Icon name="trash" className="has-hover-secondary-invert p-1" />
                 </span>
-              </td>
+              </WidthTd>
             </tr>
           ))}
         </tbody>

--- a/src/main/js/workflow/EngineConfigTable.tsx
+++ b/src/main/js/workflow/EngineConfigTable.tsx
@@ -25,7 +25,7 @@
 import React, { FC } from "react";
 import { AppliedRule, EngineConfiguration } from "../types/EngineConfig";
 import { useTranslation } from "react-i18next";
-import { Icon } from "@scm-manager/ui-components";
+import { Button } from "@scm-manager/ui-components";
 import styled from "styled-components";
 
 type Props = {
@@ -59,17 +59,17 @@ const EngineConfigTable: FC<Props> = ({ configuration, deleteRule }) => {
       <tbody>
         {configuration.rules?.map(appliedRule => (
           <tr>
-            <td>
-              <strong>{t(`workflow.rule.${appliedRule.rule}.name`)}</strong>
-            </td>
-            <td>{t(`workflow.rule.${appliedRule.rule}.description`, appliedRule.configuration)}</td>
             <VCenteredTd>
-              <Icon
-                name="trash"
-                color="inherit"
-                onClick={() => deleteRule(appliedRule)}
+              <strong>{t(`workflow.rule.${appliedRule.rule}.name`)}</strong>
+            </VCenteredTd>
+            <VCenteredTd>{t(`workflow.rule.${appliedRule.rule}.description`, appliedRule.configuration)}</VCenteredTd>
+            <VCenteredTd>
+              <Button
+                color="text"
+                icon="trash"
+                action={() => deleteRule(appliedRule)}
                 title={t("scm-review-plugin.workflow.deleteRule")}
-                className="is-clickable"
+                className="px-2"
               />
             </VCenteredTd>
           </tr>


### PR DESCRIPTION
## Proposed changes
Remove card-table action area and replace custom styling with link styled button, see https://github.com/scm-manager/scm-manager/pull/2016

### Your checklist for this pull request

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [ ] New code is covered with unit tests
- [ ] New/updated ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
