### PR TITLE
remove mention item underlining

### DIFF
--- a/gradle/changelog/remove_mention_item_underlining.yaml
+++ b/gradle/changelog/remove_mention_item_underlining.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Remove mention item underlining ([#206](https://github.com/scm-manager/scm-review-plugin/pull/206))

--- a/src/main/js/comment/MentionTextarea.tsx
+++ b/src/main/js/comment/MentionTextarea.tsx
@@ -70,7 +70,6 @@ const StyledMentionsInput = styled(MentionsInput)`
   }
   > div [class*="suggestions__item"] {
     padding: 4px;
-    border-bottom: var(--scm-border);
     :focus {
       background-color: var(--scm-column-selection);
     }
@@ -135,7 +134,7 @@ const MentionTextarea: FC<Props> = ({ value, placeholder, comment, onAddMention,
               index: number,
               focused: boolean
             ) => (
-              <StyledSuggestion className={classNames("user", { focused: focused })} index={index}>
+              <StyledSuggestion className={classNames("", { focused: focused })} index={index}>
                 {highlightedDisplay}
               </StyledSuggestion>
             )}


### PR DESCRIPTION
## Proposed changes

When mentioning other users in pull request comments, the option dropdown included a bottom border for each item.
This underlining is conflicting with the container border and is hard to see on high contrast mode. It is therefore simply removed as it serves no further purpose.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`

**Reviewer**:
- [x] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [x] All new code/logic is implemented on the right spot / "Should this be done here?"
- [x] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [x] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [x] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
