### PR TITLE
PR hit renderer column gets necessary width

### DIFF
--- a/gradle/changelog/pr_hit_label.yaml
+++ b/gradle/changelog/pr_hit_label.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: PR hit renderer column gets necessary width ([#207](https://github.com/scm-manager/scm-review-plugin/pull/207))

--- a/src/main/js/search/PullRequestHitRenderer.tsx
+++ b/src/main/js/search/PullRequestHitRenderer.tsx
@@ -71,7 +71,7 @@ const PullRequestHitRenderer: FC<HitProps> = ({ hit }) => {
           </div>
         </div>
       </Hit.Content>
-      <Hit.Right className="is-flex is-flex-direction-column">
+      <Hit.Right className="is-flex is-flex-direction-column is-align-items-flex-end">
         <DateFromNow
           date={
             hit.fields.lastModified


### PR DESCRIPTION
## Proposed changes

The status label on the search page in the Pull Request area should not change its width analogously to the text above it. Pull request hit renderer column thus gets fixed, necessary width. 

### Your checklist for this pull request

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [ ] New code is covered with unit tests
- [ ] New/updated ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
