### PR TITLE
Fix branch name in PR tags

### DIFF
--- a/gradle/changelog/branch_name_clipped_correctly.yaml
+++ b/gradle/changelog/branch_name_clipped_correctly.yaml
@@ -1,2 +1,2 @@
 - type: fixed
-  description: Branch name in PR view is clipped at the end and the clipping is marked with ellipsis ([#205](https://github.com/scm-manager/scm-review-plugin/pull/205))
+  description: Branch name in PR view is clipped at the end and the clipping is marked with ellipsis ([#208](https://github.com/scm-manager/scm-review-plugin/pull/208))

--- a/gradle/changelog/branch_name_clipped_correctly.yaml
+++ b/gradle/changelog/branch_name_clipped_correctly.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Branch name in PR view is clipped at the end and the clipping is marked with ellipsis ([#205](https://github.com/scm-manager/scm-review-plugin/pull/205))

--- a/src/main/js/BranchTag.tsx
+++ b/src/main/js/BranchTag.tsx
@@ -35,7 +35,6 @@ const ShortTag = styled(Tag).attrs(() => ({
   max-width: 25em;
   justify-content: left !important;
   display: inline-block !important;
-  direction: rtl;
 `;
 
 type Props = {

--- a/src/main/js/BranchTag.tsx
+++ b/src/main/js/BranchTag.tsx
@@ -33,7 +33,6 @@ const ShortTag = styled(Tag).attrs(() => ({
   text-overflow: ellipsis;
   white-space: nowrap;
   max-width: 25em;
-  justify-content: left !important;
   display: inline-block !important;
 `;
 

--- a/src/main/js/BranchTag.tsx
+++ b/src/main/js/BranchTag.tsx
@@ -33,6 +33,9 @@ const ShortTag = styled(Tag).attrs(() => ({
   text-overflow: ellipsis;
   white-space: nowrap;
   max-width: 25em;
+  justify-content: left !important;
+  display: inline-block !important;
+  direction: rtl;
 `;
 
 type Props = {

--- a/src/main/js/PullRequestDetails.tsx
+++ b/src/main/js/PullRequestDetails.tsx
@@ -122,6 +122,10 @@ const IgnoredMergeObstacles = styled.div`
   border-bottom: 1px solid hsla(0, 0%, 85.9%, 0.5);
 `;
 
+const PRArrow = styled.i`
+  vertical-align: super;
+`;
+
 type UserEntryProps = {
   labelKey: string;
   displayName: string;
@@ -294,7 +298,7 @@ const PullRequestDetails: FC<Props> = ({ repository, pullRequest }) => {
         <MediaWithTopBorder>
           <div className="media-content">
             <BranchTag label={pullRequest.source} title={pullRequest.source} />{" "}
-            <i className="fas fa-long-arrow-alt-right" />{" "}
+            <PRArrow className="fas fa-long-arrow-alt-right" />{" "}
             <BranchTag label={pullRequest.target} title={pullRequest.target} />
             {targetBranchDeletedWarning}
           </div>

--- a/src/main/js/PullRequestDetails.tsx
+++ b/src/main/js/PullRequestDetails.tsx
@@ -123,7 +123,7 @@ const IgnoredMergeObstacles = styled.div`
 `;
 
 const PRArrow = styled.i`
-  vertical-align: super;
+  vertical-align: 0.55rem;
 `;
 
 type UserEntryProps = {

--- a/src/main/js/PullRequestDetails.tsx
+++ b/src/main/js/PullRequestDetails.tsx
@@ -51,9 +51,9 @@ import ReducedMarkdownView from "./ReducedMarkdownView";
 import OverrideModalRow from "./OverrideModalRow";
 import PullRequestTitle from "./PullRequestTitle";
 import Statusbar from "./workflow/Statusbar";
-import BranchTag from "./BranchTag";
 import PullRequestStatusTag from "./PullRequestStatusTag";
 import ChangeNotificationContext from "./ChangeNotificationContext";
+import SourceTargetBranchDisplay from "./SourceTargetBranchDisplay";
 
 type Props = {
   repository: Repository;
@@ -296,12 +296,9 @@ const PullRequestDetails: FC<Props> = ({ repository, pullRequest }) => {
           </div>
         </div>
         <MediaWithTopBorder>
-          <div className="media-content">
-            <BranchTag label={pullRequest.source} title={pullRequest.source} />{" "}
-            <PRArrow className="fas fa-long-arrow-alt-right" />{" "}
-            <BranchTag label={pullRequest.target} title={pullRequest.target} />
+          <SourceTargetBranchDisplay source={pullRequest.source} target={pullRequest.target} className="media-content">
             {targetBranchDeletedWarning}
-          </div>
+          </SourceTargetBranchDisplay>
           <div className="media-right">
             <PullRequestStatusTag status={pullRequest.status || "OPEN"} emergencyMerged={pullRequest.emergencyMerged} />
           </div>

--- a/src/main/js/PullRequestDetails.tsx
+++ b/src/main/js/PullRequestDetails.tsx
@@ -250,9 +250,11 @@ const PullRequestDetails: FC<Props> = ({ repository, pullRequest }) => {
   }
 
   const targetBranchDeletedWarning = targetBranchDeleted ? (
-    <Tooltip className="icon has-text-warning" message={t("scm-review-plugin.pullRequest.details.targetDeleted")}>
-      <i className="fas fa-exclamation-triangle" />
-    </Tooltip>
+    <span className="ml-2">
+      <Tooltip className="icon has-text-warning" message={t("scm-review-plugin.pullRequest.details.targetDeleted")}>
+        <i className="fas fa-exclamation-triangle" />
+      </Tooltip>
+    </span>
   ) : null;
 
   const tasksDone = pullRequest.tasks ? pullRequest.tasks.done : 0;

--- a/src/main/js/SourceTargetBranchDisplay.tsx
+++ b/src/main/js/SourceTargetBranchDisplay.tsx
@@ -21,34 +21,32 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import React, { FC } from "react";
-import styled from "styled-components";
-import { Tag } from "@scm-manager/ui-components";
 
-const ShortTag = styled(Tag).attrs(() => ({
-  className: "is-medium",
-  color: "light"
-}))`
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  max-width: 25em;
-  height: initial !important;
-  display: inline-block !important;
-  padding: 0.25em 0.75em;
-`;
+import React, { FC } from "react";
+import BranchTag from "./BranchTag";
+import classNames from "classnames";
 
 type Props = {
-  label: string;
-  title: string;
+  className?: string;
+  wrapper?: React.ElementType;
+  source: string;
+  target: string;
 };
 
-const BranchTag: FC<Props> = ({ label, title }) => {
-  return (
-    <span className="is-flex align-items-center">
-      <ShortTag title={title}>{label}</ShortTag>
-    </span>
+const SourceTargetBranchDisplay: FC<Props> = ({ className, children, source, target, wrapper = "div" }) => {
+  const content = (
+    <>
+      <BranchTag label={source} title={source} />
+      <i className="fas fa-long-arrow-alt-right m-1" />
+      <BranchTag label={target} title={target} />
+    </>
+  );
+  return React.createElement(
+    wrapper,
+    { className: classNames(className, "is-flex", "is-align-items-center", "is-flex-wrap-wrap") },
+    content,
+    children
   );
 };
 
-export default BranchTag;
+export default SourceTargetBranchDisplay;

--- a/src/main/js/search/PullRequestHitRenderer.tsx
+++ b/src/main/js/search/PullRequestHitRenderer.tsx
@@ -27,8 +27,8 @@ import { DateFromNow, Hit, HitProps, Notification, RepositoryAvatar, TextHitFiel
 import { ValueHitField } from "@scm-manager/ui-types";
 import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import BranchTag from "../BranchTag";
 import PullRequestStatusTag from "../PullRequestStatusTag";
+import SourceTargetBranchDisplay from "../SourceTargetBranchDisplay";
 
 const PullRequestHitRenderer: FC<HitProps> = ({ hit }) => {
   const [t] = useTranslation("plugins");
@@ -57,17 +57,12 @@ const PullRequestHitRenderer: FC<HitProps> = ({ hit }) => {
             <p>
               <TextHitField field="description" hit={hit} truncateValueAt={1024} />
             </p>
-            <p className="mt-1">
-              <BranchTag
-                label={(hit.fields.source as ValueHitField).value as string}
-                title={t("scm-review-plugin.search.source")}
-              />{" "}
-              <i className="fas fa-long-arrow-alt-right" />{" "}
-              <BranchTag
-                label={(hit.fields.target as ValueHitField).value as string}
-                title={t("scm-review-plugin.search.target")}
-              />
-            </p>
+            <SourceTargetBranchDisplay
+              wrapper="p"
+              className="mt-1"
+              source={(hit.fields.source as ValueHitField).value as string}
+              target={(hit.fields.target as ValueHitField).value as string}
+            />
           </div>
         </div>
       </Hit.Content>


### PR DESCRIPTION
## Proposed changes
The branch names of branches involved in a pull request may be long and not fit the space in the ui. To make sure, that they are easily recognized the first part of the name will always be visible. A title-tag ensures, that the full name is accessible. The clipped part is marked with ellipsis. 
Resolves #205 

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [ ] New code is covered with unit tests
- [ ] New/updated ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [x] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [x] All new code/logic is implemented on the right spot / "Should this be done here?"
- [x] UI changes fits into the layout
- [x] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [x] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [x] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
