### PR TITLE
Enlarge color difference between options in Confirm Alert

### DIFF
--- a/gradle/changelog/confirm_alert_button.yaml
+++ b/gradle/changelog/confirm_alert_button.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Enlarge color difference between options in Confirm Alert ([#211](https://github.com/scm-manager/scm-review-plugin/pull/211))

--- a/src/main/js/RejectButton.tsx
+++ b/src/main/js/RejectButton.tsx
@@ -44,11 +44,11 @@ const RejectButton: FC<Props> = ({ reject, loading }) => {
           close={() => setShowModal(false)}
           buttons={[
             {
-              className: "is-outlined",
               label: t("scm-review-plugin.showPullRequest.rejectButton.confirmAlert.submit"),
               onClick: () => reject()
             },
             {
+              className: "is-info",
               label: t("scm-review-plugin.showPullRequest.rejectButton.confirmAlert.cancel"),
               onClick: () => setShowModal(false),
               autofocus: true

--- a/src/main/js/comment/PullRequestComment.tsx
+++ b/src/main/js/comment/PullRequestComment.tsx
@@ -220,11 +220,11 @@ const PullRequestComment: FC<Props> = ({ repository, pullRequest, parent, commen
           message={t("scm-review-plugin.comment.confirmDeleteAlert.message")}
           buttons={[
             {
-              className: "is-outlined",
               label: t("scm-review-plugin.comment.confirmDeleteAlert.submit"),
               onClick: () => remove(comment)
             },
             {
+              className: "is-info",
               label: t("scm-review-plugin.comment.confirmDeleteAlert.cancel"),
               onClick: () => null,
               autofocus: true


### PR DESCRIPTION
## Proposed changes

Enlarge color difference between options in Confirm Alert

### Your checklist for this pull request

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [ ] New code is covered with unit tests
- [ ] New/updated ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
