### PR TITLE
Fix paging for too large page numbers

### DIFF
--- a/gradle/changelog/fix_paging.yaml
+++ b/gradle/changelog/fix_paging.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Fix paging for too large page numbers ([#213](https://github.com/scm-manager/scm-review-plugin/pull/213))

--- a/src/main/js/Changesets.tsx
+++ b/src/main/js/Changesets.tsx
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 import React, { FC, useEffect, useState } from "react";
-import { useRouteMatch } from "react-router-dom";
+import { Redirect, useRouteMatch } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { Repository } from "@scm-manager/ui-types";
 import { usePullRequestChangesets } from "./pullRequest";
@@ -72,6 +72,9 @@ const Changesets: FC<Props> = ({ repository, pullRequest, shouldFetchChangesets 
     return <ErrorNotification error={error} />;
   } else if (isLoading) {
     return <Loading />;
+  } else if (changesets && changesets.pageTotal < page && page > 1) {
+    const url = `/repo/${repository.namespace}/${repository.name}/pull-request/${pullRequest.id}/changesets/${changesets.pageTotal}`;
+    return <Redirect to={url} />;
   } else if (changesets && changesets._embedded && changesets._embedded.changesets) {
     if (changesets._embedded.changesets?.length !== 0) {
       return (

--- a/src/main/js/PullRequestList.tsx
+++ b/src/main/js/PullRequestList.tsx
@@ -30,7 +30,7 @@ import PullRequestTable from "./table/PullRequestTable";
 import StatusSelector from "./table/StatusSelector";
 import { usePullRequests } from "./pullRequest";
 import { PullRequest } from "./types/PullRequest";
-import { useHistory, useLocation, useRouteMatch } from "react-router-dom";
+import { Redirect, useHistory, useLocation, useRouteMatch } from "react-router-dom";
 
 const ScrollingTable = styled.div`
   overflow-x: auto;
@@ -96,10 +96,14 @@ const PullRequestList: FC<Props> = ({ repository }) => {
     );
   }
 
-  const to = `/repo/${repository.namespace}/${repository.name}/pull-requests/add/changesets/`;
+  const url = `/repo/${repository.namespace}/${repository.name}/pull-requests`;
+
+  if (data && data.pageTotal < page && page > 1) {
+    return <Redirect to={`${url}/${data.pageTotal}`} />;
+  }
 
   const createButton = data?._links?.create ? (
-    <CreateButton label={t("scm-review-plugin.pullRequests.createButton")} link={to} />
+    <CreateButton label={t("scm-review-plugin.pullRequests.createButton")} link={`${url}/add/changesets/`} />
   ) : null;
 
   return (


### PR DESCRIPTION
## Proposed changes

On some pages with pagination, the user is led to believe that no data is available if a page with page number which it too high is accessed. However, since we show the page number to the outside and the user can access it through the URL, we must also provide appropriate handling. The underlying data can change and so can the number of pages. Now, if a bookmark was saved from an older version, the link should still lead to a destination.

This PR refers to https://github.com/scm-manager/scm-manager/pull/2097.

### Your checklist for this pull request

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [ ] New code is covered with unit tests
- [ ] New/updated ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
